### PR TITLE
Add options to disable doc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,9 @@ endif (ENABLE_UNIT_TESTS)
 add_subdirectory (src)
 add_subdirectory (tools)
 add_subdirectory (lua)
+if (MAKE_DOC)
 add_subdirectory (doc)
+endif (MAKE_DOC)
 add_subdirectory (daqs)
 
 # Miscellaneous stuff.  Does NOT directly effect snort's building environment

--- a/Makefile.am
+++ b/Makefile.am
@@ -4,8 +4,12 @@ SUBDIRS = \
 src \
 lua \
 tools \
-doc \
 daqs
+
+if MAKE_DOC
+SUBDIRS += \
+doc
+endif
 
 EXTRA_DIST = \
 snort.pc.in \

--- a/cmake/create_options.cmake
+++ b/cmake/create_options.cmake
@@ -25,6 +25,7 @@ option ( ENABLE_STDLOG "Use file descriptor 3 instead of stdout for alerts" OFF 
 option ( ENABLE_TSC_CLOCK "Use timestamp counter register clock (x86 only)" OFF )
 
 # documentation
+option ( MAKE_DOC "Create the documentation" ON )
 option ( MAKE_HTML_DOC "Create the HTML documentation" ON )
 option ( MAKE_PDF_DOC "Create the PDF documentation" ON )
 option ( MAKE_TEXT_DOC "Create the text documentation" ON )

--- a/configure.ac
+++ b/configure.ac
@@ -256,6 +256,12 @@ fi
 
 AM_CONDITIONAL(LINUX, [test "x$linux" = "xyes"])
 
+AC_ARG_ENABLE(doc,
+    AS_HELP_STRING([--disable-doc],[do not make doc ]),
+    make_doc="$enableval", make_doc="yes")
+
+AM_CONDITIONAL(MAKE_DOC, [test "x$make_doc" = "xyes"])
+
 AC_ARG_ENABLE(static-ips-actions,
     AS_HELP_STRING([--disable-static-ips-actions],[do not include ips actions in binary ]),
     static_ips_actions="$enableval", static_ips_actions="yes")


### PR DESCRIPTION
doc is built by executing snort which can't work when cross-compiling so
add an option to disable doc through MAKE_DOC in cmake and --disable-doc
in autotools. These options are enabled by default to keep current
behavior.

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>