### PR TITLE
Set default paths to Lua includes and Snort config

### DIFF
--- a/lua/CMakeLists.txt
+++ b/lua/CMakeLists.txt
@@ -1,10 +1,12 @@
 
 set (LUA_SCRIPTS
     file_magic.lua
-    snort.lua
     snort_defaults.lua
 )
 
-install (FILES ${LUA_SCRIPTS}
+configure_file(snort.lua.in
+    snort.lua)
+
+install (FILES ${LUA_SCRIPTS} ${CMAKE_CURRENT_BINARY_DIR}/snort.lua
     DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/snort"
 )

--- a/lua/snort.lua.in
+++ b/lua/snort.lua.in
@@ -28,6 +28,11 @@
 -- export LUA_PATH=$DIR/include/snort/lua/?.lua\;\;
 -- export SNORT_LUA_PATH=$DIR/etc/snort
 
+lua_path = os.getenv('LUA_PATH')
+if ( not lua_path ) then
+    package.path = '${CMAKE_INSTALL_FULL_INCLUDEDIR}/${INSTALL_SUFFIX}/lua/?.lua;?;'
+end
+
 -- this depends on LUA_PATH
 -- used to load this conf into Snort
 require('snort_config')
@@ -37,7 +42,7 @@ require('snort_config')
 conf_dir = os.getenv('SNORT_LUA_PATH')
 
 if ( not conf_dir ) then
-    conf_dir = '.'
+    conf_dir = '${CMAKE_INSTALL_FULL_SYSCONFDIR}/snort'
 end
 
 ---------------------------------------------------------------------------


### PR DESCRIPTION
For most installs LUA_PATH and SNORT_LUA_PATH are known at build time; they are the directories that we have configured the appropriate files to be installed in. Set these as defaults in the installed snort.lua config file. The environment variables will take precedence if set.

I find this makes dealing with multiple installs a lot easier; I don't have to remember if I've set the environment variables to the right place (or at all).