### PR TITLE
build: Removing use of u_char and u_short macros

### DIFF
--- a/src/codecs/ip/cd_icmp6.cc
+++ b/src/codecs/ip/cd_icmp6.cc
@@ -132,7 +132,7 @@ bool Icmp6Codec::decode(const RawData& raw, CodecData& codec, DecodeData& snort)
         COPY4(ph6.dip, snort.ip_api.get_dst()->get_ip6_ptr());
         ph6.zero = 0;
         ph6.protocol = codec.ip6_csum_proto;
-        ph6.len = htons((u_short)raw.len);
+        ph6.len = htons((unsigned short)raw.len);
 
         uint16_t csum = checksum::icmp_cksum((const uint16_t*)(icmp6h), raw.len, &ph6);
 

--- a/src/codecs/ip/cd_udp.cc
+++ b/src/codecs/ip/cd_udp.cc
@@ -264,7 +264,7 @@ bool UdpCodec::decode(const RawData& raw, CodecData& codec, DecodeData& snort)
                 COPY4(ph6.dip, ip6h->ip6_dst.u6_addr32);
                 ph6.zero = 0;
                 ph6.protocol = codec.ip6_csum_proto;
-                ph6.len = htons((u_short)raw.len);
+                ph6.len = htons((unsigned short)raw.len);
 
                 csum = checksum::udp_cksum((const uint16_t*)(udph), uhlen, &ph6);
             }

--- a/src/detection/rtn_checks.cc
+++ b/src/detection/rtn_checks.cc
@@ -49,8 +49,8 @@ using namespace snort;
 static int CheckAddrPort(sfip_var_t* rule_addr, PortObject* po, Packet* p,
     uint32_t flags, int mode)
 {
-    const SfIp* pkt_addr;          /* packet IP address */
-    u_short pkt_port;                /* packet port */
+    const SfIp* pkt_addr;            /* packet IP address */
+    unsigned short pkt_port;         /* packet port */
     int global_except_addr_flag = 0; /* global exception flag is set */
     int any_port_flag = 0;           /* any port flag set */
     int except_port_flag = 0;        /* port exception flag set */

--- a/src/ips_options/asn1_util.cc
+++ b/src/ips_options/asn1_util.cc
@@ -51,10 +51,10 @@
 /*
 **  Macros
 */
-#define SF_ASN1_CLASS(c)   (((u_char)(c)) & SF_ASN1_CLASS_MASK)
-#define SF_ASN1_FLAG(c)    (((u_char)(c)) & SF_ASN1_FLAG_MASK)
-#define SF_ASN1_TAG(c)     (((u_char)(c)) & SF_ASN1_TAG_MASK)
-#define SF_ASN1_LEN_EXT(c) (((u_char)(c)) & SF_BER_LEN_MASK)
+#define SF_ASN1_CLASS(c)   (((uint8_t)(c)) & SF_ASN1_CLASS_MASK)
+#define SF_ASN1_FLAG(c)    (((uint8_t)(c)) & SF_ASN1_FLAG_MASK)
+#define SF_ASN1_TAG(c)     (((uint8_t)(c)) & SF_ASN1_TAG_MASK)
+#define SF_ASN1_LEN_EXT(c) (((uint8_t)(c)) & SF_BER_LEN_MASK)
 
 #define ASN1_OOB(s,e,d)      (!(((s) <= (d)) && ((d) < (e))))
 #define ASN1_FATAL_ERR(e)    ((e) < 0)
@@ -276,7 +276,7 @@ static int asn1_decode_ident(ASN1_TYPE* asn1_type, ASN1_DATA* asn1_data)
 **  @retval SF_BER_LEN_DEF_SHORT one byte length < 127
 **  @retval SF_BER_LEN_INDEF indeterminate length
 */
-static int asn1_decode_len_type(const u_char* data)
+static int asn1_decode_len_type(const uint8_t* data)
 {
     int iExt;
 
@@ -496,7 +496,7 @@ static int asn1_is_eoc(ASN1_TYPE* asn1)
 **  @retval ASN1_ERR_INVALID_ARG invalid argument
 **  @retval ASN1_ERR_OOB out of bounds
 */
-static int asn1_decode_type(const u_char** data, u_int* len, ASN1_TYPE** asn1_type)
+static int asn1_decode_type(const uint8_t** data, u_int* len, ASN1_TYPE** asn1_type)
 {
     ASN1_DATA asn1data;
     u_int uiRawLen;
@@ -647,14 +647,14 @@ valid:
 **  @retval  ASN1_OK function successful
 **  @retval !ASN1_OK lots of error conditions, figure it out
 */
-int asn1_decode(const u_char* data, u_int len, ASN1_TYPE** asn1_type)
+int asn1_decode(const uint8_t* data, u_int len, ASN1_TYPE** asn1_type)
 {
     ASN1_TYPE* cur;
     ASN1_TYPE* child = nullptr;
     ASN1_TYPE* indef;
     ASN1_TYPE* asnstack[ASN1_MAX_STACK];
 
-    const u_char* end;
+    const uint8_t* end;
     u_int con_len;
     int index = 0;
     int iRet;

--- a/src/ips_options/ips_flags.cc
+++ b/src/ips_options/ips_flags.cc
@@ -54,9 +54,9 @@ static THREAD_LOCAL ProfileStats tcpFlagsPerfStats;
 
 struct TcpFlagCheckData
 {
-    u_char mode;
-    u_char tcp_flags;
-    u_char tcp_mask; /* Mask to take away from the flags check */
+    uint8_t mode;
+    uint8_t tcp_flags;
+    uint8_t tcp_mask; /* Mask to take away from the flags check */
 };
 
 class TcpFlagOption : public IpsOption
@@ -126,7 +126,7 @@ IpsOption::EvalStatus TcpFlagOption::eval(Cursor&, Packet* p)
      */
 
     TcpFlagCheckData* flagptr = &config;
-    u_char tcp_flags = p->ptrs.tcph->th_flags & (0xFF ^ flagptr->tcp_mask);
+    uint8_t tcp_flags = p->ptrs.tcph->th_flags & (0xFF ^ flagptr->tcp_mask);
 
     switch ((flagptr->mode))
     {

--- a/src/ips_options/ips_ipopts.cc
+++ b/src/ips_options/ips_ipopts.cc
@@ -38,7 +38,7 @@ static THREAD_LOCAL ProfileStats ipOptionPerfStats;
 struct IpOptionData
 {
     ip::IPOptionCodes ip_option;
-    u_char any_flag;
+    uint8_t any_flag;
 };
 
 class IpOptOption : public IpsOption

--- a/src/ips_options/ips_session.cc
+++ b/src/ips_options/ips_session.cc
@@ -249,8 +249,8 @@ static FILE* OpenSessionFile(Packet* p)
 
 static void DumpSessionData(FILE* fp, Packet* p, SessionData* sessionData)
 {
-    const u_char* idx;
-    const u_char* end;
+    const uint8_t* idx;
+    const uint8_t* end;
     char conv[] = "0123456789ABCDEF"; /* xlation lookup table */
 
     if (p->dsize == 0 || p->data == nullptr || (p->ptrs.decode_flags & DECODE_FRAG))

--- a/src/loggers/log_pcap.cc
+++ b/src/loggers/log_pcap.cc
@@ -132,7 +132,7 @@ static void LogTcpdumpSingle(
     if ( data->limit && (context.size + dumpSize > data->limit) )
         TcpdumpRollLogFile(data);
 
-    pcap_dump((u_char*)context.dumpd, reinterpret_cast<const struct pcap_pkthdr*>(p->pkth), p->pkt);
+    pcap_dump((uint8_t*)context.dumpd, reinterpret_cast<const struct pcap_pkthdr*>(p->pkth), p->pkt);
     context.size += dumpSize;
 
     if (!SnortConfig::line_buffered_logging())  // FIXIT-L misnomer

--- a/src/network_inspectors/arp_spoof/arp_spoof.cc
+++ b/src/network_inspectors/arp_spoof/arp_spoof.cc
@@ -194,24 +194,24 @@ void ArpSpoof::eval(Packet* p)
     switch (ntohs(ah->ea_hdr.ar_op))
     {
     case ARPOP_REQUEST:
-        if (memcmp((const u_char*)dst_mac_addr, (const u_char*)bcast, 6) != 0)
+        if (memcmp((const uint8_t*)dst_mac_addr, (const uint8_t*)bcast, 6) != 0)
         {
             DetectionEngine::queue_event(GID_ARP_SPOOF, ARPSPOOF_UNICAST_ARP_REQUEST);
         }
-        else if (memcmp((const u_char*)src_mac_addr,
-            (const u_char*)ah->arp_sha, 6) != 0)
+        else if (memcmp((const uint8_t*)src_mac_addr,
+            (const uint8_t*)ah->arp_sha, 6) != 0)
         {
             DetectionEngine::queue_event(GID_ARP_SPOOF, ARPSPOOF_ETHERFRAME_ARP_MISMATCH_SRC);
         }
         break;
     case ARPOP_REPLY:
-        if (memcmp((const u_char*)src_mac_addr,
-            (const u_char*)ah->arp_sha, 6) != 0)
+        if (memcmp((const uint8_t*)src_mac_addr,
+            (const uint8_t*)ah->arp_sha, 6) != 0)
         {
             DetectionEngine::queue_event(GID_ARP_SPOOF, ARPSPOOF_ETHERFRAME_ARP_MISMATCH_SRC);
         }
-        else if (memcmp((const u_char*)dst_mac_addr,
-            (const u_char*)ah->arp_tha, 6) != 0)
+        else if (memcmp((const uint8_t*)dst_mac_addr,
+            (const uint8_t*)ah->arp_tha, 6) != 0)
         {
             DetectionEngine::queue_event(GID_ARP_SPOOF, ARPSPOOF_ETHERFRAME_ARP_MISMATCH_DST);
         }

--- a/src/network_inspectors/port_scan/ps_detect.cc
+++ b/src/network_inspectors/port_scan/ps_detect.cc
@@ -418,11 +418,11 @@ void PortScan::ps_proto_update_window(unsigned interval, PS_PROTO* proto, time_t
 **  @param PS_PROTO pointer to structure to update
 **  @param int      number to increment portscan counter
 **  @param u_long   IP address of other host
-**  @param u_short  port/ip_proto to track
+**  @param unsigned short  port/ip_proto to track
 **  @param time_t   time the packet was received. update windows.
 */
 int PortScan::ps_proto_update(PS_PROTO* proto, int ps_cnt, int pri_cnt,
-    unsigned window, const SfIp* ip, u_short port, time_t pkt_time)
+    unsigned window, const SfIp* ip, unsigned short port, time_t pkt_time)
 {
     if (!proto)
         return 0;
@@ -734,12 +734,12 @@ void PortScan::ps_tracker_update_ip(PS_PKT* ps_pkt, PS_TRACKER* scanner,
 
     if (scanned)
     {
-        ps_proto_update(&scanned->proto, 1, 0, win, &cleared, (u_short)p->get_ip_proto_next(), 0);
+        ps_proto_update(&scanned->proto, 1, 0, win, &cleared, (unsigned short)p->get_ip_proto_next(), 0);
     }
 
     if (scanner)
     {
-        ps_proto_update(&scanner->proto, 1, 0, win, &cleared, (u_short)p->get_ip_proto_next(), 0);
+        ps_proto_update(&scanner->proto, 1, 0, win, &cleared, (unsigned short)p->get_ip_proto_next(), 0);
     }
 }
 

--- a/src/network_inspectors/port_scan/ps_inspect.h
+++ b/src/network_inspectors/port_scan/ps_inspect.h
@@ -65,7 +65,7 @@ private:
     void ps_proto_update_window(unsigned window, PS_PROTO*, time_t pkt_time);
 
     int ps_proto_update( PS_PROTO*, int ps_cnt, int pri_cnt, unsigned window, const snort::SfIp* ip,
-        u_short port, time_t pkt_time);
+        unsigned short port, time_t pkt_time);
 
     void ps_tracker_update_ip(PS_PKT*, PS_TRACKER* scanner, PS_TRACKER* scanned);
     void ps_tracker_update_tcp(PS_PKT*, PS_TRACKER* scanner, PS_TRACKER* scanned);

--- a/src/protocols/wlan.h
+++ b/src/protocols/wlan.h
@@ -71,7 +71,7 @@ struct WifiHdr
 #define WLAN_TYPE_DATA_ACKPL   0x78     /* 0111    10  CF-Ack+CF-Poll  */
 
 /*** Flags for IEEE 802.11 Frame Control **
-   The following are designed to be bitwise-AND-d in an 8-bit u_char */
+   The following are designed to be bitwise-AND-d in a uint8_t */
 #define WLAN_FLAG_TODS      0x0100    /* To DS Flag   10000000 */
 #define WLAN_FLAG_FROMDS    0x0200    /* From DS Flag 01000000 */
 #define WLAN_FLAG_FRAG      0x0400    /* More Frag    00100000 */

--- a/tools/u2boat/u2boat.cc
+++ b/tools/u2boat/u2boat.cc
@@ -174,7 +174,7 @@ static int PcapConversion(u2record* rec, FILE* output)
 
     /* Write to the pcap file */
     pcap_data = rec->data + sizeof(Serial_Unified2Packet) - 4;
-    pcap_dump( (u_char*)output, &pcap_hdr, (u_char*)pcap_data);
+    pcap_dump( (uint8_t*)output, &pcap_hdr, (uint8_t*)pcap_data);
 
     return SUCCESS;
 }


### PR DESCRIPTION
**Let's try this again now that I think I have my git foo correct ;)**
**Please 'learn' me if I'm still jacking it up**

This is the first pull request of a series to integrate changes I have made to get Snort3 to build on Alpine Linux leveraging the musl libc implementation. The end goal is to create a thin containerized version Snort3 that will build from the GitHub source.

To validate the changes, I have applied them to my fork the GitHub master and built w/ unit tests and run snort --catch-test all. Both without any errors.

This PR removes the use of the `u_char` and `u_short` macros. I have replaced them with `uint8_t` and `unsigned short` respectively.