### PR TITLE
build: Handle strerror_r when compiling with gcc but not glibc

### DIFF
--- a/src/utils/util.cc
+++ b/src/utils/util.cc
@@ -606,7 +606,8 @@ const char* get_error(int errnum)
     static THREAD_LOCAL char buf[128];
 
 #if (defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE < 200112L && \
-        defined(_XOPEN_SOURCE) && _XOPEN_SOURCE < 600) || _GNU_SOURCE
+     defined(_XOPEN_SOURCE) && _XOPEN_SOURCE < 600) || \
+    (defined(__GLIBC__) && defined(_GNU_SOURCE))
     return strerror_r(errnum, buf, sizeof(buf));
 #else
     (void)strerror_r(errnum, buf, sizeof(buf));


### PR DESCRIPTION
As part of the work to build snort3 on Alpine Linux w/ llvm musl libc, we need to check not just for gcc/g++ but also for glibc in order to get the correct form of strerror_r