### PR TITLE
build: Alpine Integration -clear segfault in cpputest on musl/Alpine

### DIFF
--- a/src/network_inspectors/appid/test/appid_detector_test.cc
+++ b/src/network_inspectors/appid/test/appid_detector_test.cc
@@ -36,9 +36,6 @@
 #include <CppUTest/CommandLineTestRunner.h>
 #include <CppUTest/TestHarness.h>
 
-Flow* flow = nullptr;
-AppIdSession* mock_session = nullptr;
-
 void AppIdHttpSession::set_http_change_bits(AppidChangeBits&, HttpFieldIds) {}
 
 class TestDetector : public AppIdDetector
@@ -54,6 +51,9 @@ public:
 
 TEST_GROUP(appid_detector_tests)
 {
+    Flow* flow = nullptr;
+    AppIdSession* mock_session = nullptr;
+
     void setup() override
     {
         MemoryLeakWarningPlugin::turnOffNewDeleteOverloads();

--- a/src/network_inspectors/appid/test/appid_detector_test.cc
+++ b/src/network_inspectors/appid/test/appid_detector_test.cc
@@ -57,6 +57,8 @@ TEST_GROUP(appid_detector_tests)
     void setup() override
     {
         MemoryLeakWarningPlugin::turnOffNewDeleteOverloads();
+        mock_session = new AppIdSession(IpProtocol::TCP, nullptr, 1492, appid_inspector);
+        mock_session->get_http_session();
         flow = new Flow;
         flow->set_flow_data(mock_session);
     }
@@ -64,6 +66,7 @@ TEST_GROUP(appid_detector_tests)
     void teardown() override
     {
         delete flow;
+        delete mock_session;
         MemoryLeakWarningPlugin::turnOnNewDeleteOverloads();
     }
 };
@@ -115,8 +118,6 @@ TEST(appid_detector_tests, get_code_string)
 int main(int argc, char** argv)
 {
     mock_init_appid_pegs();
-    mock_session = new AppIdSession(IpProtocol::TCP, nullptr, 1492, appid_inspector);
-    mock_session->get_http_session();
     int rc = CommandLineTestRunner::RunAllTests(argc, argv);
     mock_cleanup_appid_pegs();
     return rc;


### PR DESCRIPTION
The `appid_detector_test` UT was segfaulting when doing a `make -j$(nproc) check` on Alpine w/ musl libc. gdb took me deep into the bowels of the cpputest MemoryLeak detector where it was crapping out. After doing a bunch of reading, I saw a couple of mentions that cpputest's MemoryLeak detector would sometimes get unhappy if you allocate from the heap prior to instantiating your tests. So, I just moved the creation of the mocked session from main into the test setup and teardown inside of the disablement of the `NewDeleteOverloads` from the cpputest `MemoryLeakWarningPlugin`. Lo and behold, no more segfault. I'm pretty sure this change is valid as the UTs do not build on one another so re-initiailizing the session between each of them does not invalidate any of the tests.

Note that this segfault does not occur on glibc. I will attempt to code up a simple reproduction case and open an issue w/ cpputest. In the meantime a simple refactor clears the **LAST** hurdle to clean native build of Snort3 on Alpine. 

🎉 Woot! 🎉 