### PR TITLE
Fix GCC 8 format truncation warnings in DAQ plugins

### DIFF
--- a/daqs/daq_file.c
+++ b/daqs/daq_file.c
@@ -71,7 +71,7 @@ static int file_setup(FileImpl* impl)
     }
     else if ( (impl->fid = open(impl->name, O_RDONLY|O_NONBLOCK)) < 0 )
     {
-        char error_msg[1024] = {0};
+        char error_msg[200] = {0};
         if (strerror_r(errno, error_msg, sizeof(error_msg)) == 0)
             DPE(impl->error, "%s: can't open file (%s)\n", DAQ_NAME, error_msg);
         else
@@ -109,7 +109,7 @@ static int file_read(FileImpl* impl)
     {
         if (errno != EINTR)
         {
-            char error_msg[1024] = {0};
+            char error_msg[200] = {0};
             if (strerror_r(errno, error_msg, sizeof(error_msg)) == 0)
                 DPE(impl->error, "%s: can't read from file (%s)\n",
                     DAQ_NAME, error_msg);

--- a/daqs/daq_hext.c
+++ b/daqs/daq_hext.c
@@ -471,7 +471,7 @@ static int hext_setup(HextImpl* impl)
     }
     else if ( !(impl->fyle = fopen(impl->name, "r")) )
     {
-        char error_msg[1024] = {0};
+        char error_msg[200] = {0};
         if (strerror_r(errno, error_msg, sizeof(error_msg)) == 0)
             DPE(impl->error, "%s: can't open file (%s)\n",
                 DAQ_NAME, error_msg);
@@ -528,7 +528,7 @@ static int hext_read(HextImpl* impl)
     {
         if (errno != EINTR)
         {
-            char error_msg[1024] = {0};
+            char error_msg[200] = {0};
             if (strerror_r(errno, error_msg, sizeof(error_msg)) == 0)
                 DPE(impl->error, "%s: can't read from file (%s)\n",
                     DAQ_NAME, error_msg);


### PR DESCRIPTION
The buffer passed to strerror_r() is larger than the format buffer provided by DPE. GCC 8 complains about the potential truncation, so limit the size of the buffer. Biggest error string in glibc is ~ 50 characters so this should be plenty, but if not we'll gracefully fallback to just the error number.

These are the only errors I'm seeing on a warnings enabled build at present:

In file included from src/daqs/daq_hext.c:39:
src/daqs/daq_hext.c: In function ‘hext_setup’:
src/daqs/daq_hext.c:476:30: warning: ‘%s’ directive output may be truncated writing up to 1023 bytes into a region of size 233 [-Wformat-truncation=]
             DPE(impl->error, "%s: can't open file (%s)\n",
                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
                 DAQ_NAME, error_msg);
                           ~~~~~~~~~
src/daqs/daq_hext.c:476:13: note: ‘snprintf’ output between 26 and 1049 bytes into a destination of size 256
             DPE(impl->error, "%s: can't open file (%s)\n",
             ^~~
src/daqs/daq_hext.c: In function ‘hext_read’:
src/daqs/daq_hext.c:533:34: warning: ‘%s’ directive output may be truncated writing up to 1023 bytes into a region of size 228 [-Wformat-truncation=]
                 DPE(impl->error, "%s: can't read from file (%s)\n",
                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                     DAQ_NAME, error_msg);
                               ~~~~~~~~~
src/daqs/daq_hext.c:533:17: note: ‘snprintf’ output between 31 and 1054 bytes into a destination of size 256
                 DPE(impl->error, "%s: can't read from file (%s)\n",
                 ^~~
In file included from src/daqs/daq_file.c:36:
src/daqs/daq_file.c: In function ‘file_setup’:
src/daqs/daq_file.c:76:30: warning: ‘%s’ directive output may be truncated writing up to 1023 bytes into a region of size 233 [-Wformat-truncation=]
             DPE(impl->error, "%s: can't open file (%s)\n", DAQ_NAME, error_msg);
                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~            ~~~~~~~~~
src/daqs/daq_file.c:76:13: note: ‘snprintf’ output between 26 and 1049 bytes into a destination of size 256
             DPE(impl->error, "%s: can't open file (%s)\n", DAQ_NAME, error_msg);
             ^~~
src/daqs/daq_file.c: In function ‘file_read’:
src/daqs/daq_file.c:114:34: warning: ‘%s’ directive output may be truncated writing up to 1023 bytes into a region of size 228 [-Wformat-truncation=]
                 DPE(impl->error, "%s: can't read from file (%s)\n",
                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                     DAQ_NAME, error_msg);
                               ~~~~~~~~~
src/daqs/daq_file.c:114:17: note: ‘snprintf’ output between 31 and 1054 bytes into a destination of size 256
                 DPE(impl->error, "%s: can't read from file (%s)\n",
                 ^~~