### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/src/file_api/file_cache.cc
+++ b/src/file_api/file_cache.cc
@@ -134,7 +134,7 @@ FileContext* FileCache::add(const FileHashKey& hashKey, int64_t timeout)
     struct timeval now;
     packet_gettimeofday(&now);
 
-    struct timeval time_to_add = { timeout, 0 };
+    struct timeval time_to_add = { static_cast<time_t>(timeout), 0 };
     timeradd(&now, &time_to_add, &new_node.cache_expire_time);
 
     new_node.file = new FileContext;
@@ -187,7 +187,7 @@ FileContext* FileCache::find(const FileHashKey& hashKey, int64_t timeout)
     }
 
     struct timeval next_expire_time;
-    struct timeval time_to_add = { timeout, 0 };
+    struct timeval time_to_add = { static_cast<time_t>(timeout), 0 };
     timeradd(&now, &time_to_add, &next_expire_time);
 
     //  Refresh the timer on the cache.
@@ -314,7 +314,7 @@ bool FileCache::apply_verdict(Packet* p, FileContext* file_ctx, FileVerdict verd
 
             if (!timerisset(&file_ctx->pending_expire_time))
             {
-                add_time = { lookup_timeout, 0 };
+                add_time = { static_cast<time_t>(lookup_timeout), 0 };
                 timeradd(&now, &add_time, &file_ctx->pending_expire_time);
 
                 if (PacketTracer::is_active())


### PR DESCRIPTION
[560/828] /usr/bin/c++  -DHAVE_CONFIG_H -Dinline=inline -Drestrict=__restrict -I/wrkdirs/usr/ports/security/snort3/work/snort3-3.0.0-252/src/network_inspectors -I/wrkdirs/usr/ports/security/snort3/work/snort3-3.0.0-252/src -I/usr/local/include/luajit-2.0 -I. -I/wrkdirs/usr/ports/security/snort3/work/snort3-3.0.0-252 -I/usr/local/include -O2 -pipe -DLIBICONV_PLUG -fstack-protector -fno-strict-aliasing  -DLIBICONV_PLUG  -fvisibility=hidden   -DNDEBUG    -O2 -pipe -DLIBICONV_PLUG -fstack-protector -fno-strict-aliasing  -DLIBICONV_PLUG   -std=c++11 -MD -MT src/file_api/CMakeFiles/file_api.dir/file_cache.cc.o -MF src/file_api/CMakeFiles/file_api.dir/file_cache.cc.o.d -o src/file_api/CMakeFiles/file_api.dir/file_cache.cc.o -c /wrkdirs/usr/ports/security/snort3/work/snort3-3.0.0-252/src/file_api/file_cache.cc
FAILED: src/file_api/CMakeFiles/file_api.dir/file_cache.cc.o 
/usr/bin/c++  -DHAVE_CONFIG_H -Dinline=inline -Drestrict=__restrict -I/wrkdirs/usr/ports/security/snort3/work/snort3-3.0.0-252/src/network_inspectors -I/wrkdirs/usr/ports/security/snort3/work/snort3-3.0.0-252/src -I/usr/local/include/luajit-2.0 -I. -I/wrkdirs/usr/ports/security/snort3/work/snort3-3.0.0-252 -I/usr/local/include -O2 -pipe -DLIBICONV_PLUG -fstack-protector -fno-strict-aliasing  -DLIBICONV_PLUG  -fvisibility=hidden   -DNDEBUG    -O2 -pipe -DLIBICONV_PLUG -fstack-protector -fno-strict-aliasing  -DLIBICONV_PLUG   -std=c++11 -MD -MT src/file_api/CMakeFiles/file_api.dir/file_cache.cc.o -MF src/file_api/CMakeFiles/file_api.dir/file_cache.cc.o.d -o src/file_api/CMakeFiles/file_api.dir/file_cache.cc.o -c /wrkdirs/usr/ports/security/snort3/work/snort3-3.0.0-252/src/file_api/file_cache.cc
/wrkdirs/usr/ports/security/snort3/work/snort3-3.0.0-252/src/file_api/file_cache.cc:190:36: error: non-constant-expression cannot be narrowed from type 'int64_t' (aka 'long long') to 'time_t' (aka 'int') in initializer list [-Wc++11-narrowing]
    struct timeval time_to_add = { timeout, 0 };
                                   ^~~~~~~
/wrkdirs/usr/ports/security/snort3/work/snort3-3.0.0-252/src/file_api/file_cache.cc:190:36: note: insert an explicit cast to silence this issue
    struct timeval time_to_add = { timeout, 0 };
                                   ^~~~~~~
                                   static_cast<time_t>( )
/wrkdirs/usr/ports/security/snort3/work/snort3-3.0.0-252/src/file_api/file_cache.cc:317:30: error: non-constant-expression cannot be narrowed from type 'int64_t' (aka 'long long') to 'time_t' (aka 'int') in initializer list [-Wc++11-narrowing]
                add_time = { lookup_timeout, 0 };
                             ^~~~~~~~~~~~~~
/wrkdirs/usr/ports/security/snort3/work/snort3-3.0.0-252/src/file_api/file_cache.cc:317:30: note: insert an explicit cast to silence this issue
                add_time = { lookup_timeout, 0 };
                             ^~~~~~~~~~~~~~
                             static_cast<time_t>( )
2 errors generated.