### PR TITLE
Replace u_int8_t by uint8_t

### DIFF
--- a/src/host_tracker/host_tracker.cc
+++ b/src/host_tracker/host_tracker.cc
@@ -46,7 +46,7 @@ void HostTracker::update_last_event(uint32_t time)
     last_event = time ? time : last_seen;
 }
 
-bool HostTracker::add_mac(const u_int8_t* mac, u_int8_t ttl, u_int8_t primary)
+bool HostTracker::add_mac(const uint8_t* mac, uint8_t ttl, uint8_t primary)
 {
     if ( !mac or !memcmp(mac, zero_mac, MAC_SIZE) )
         return false;
@@ -130,7 +130,7 @@ static inline string to_time_string(uint32_t p_time)
     return buffer;
 }
 
-static inline string to_mac_string(const u_int8_t* mac)
+static inline string to_mac_string(const uint8_t* mac)
 {
     char mac_addr[18];
     snprintf(mac_addr, 18, "%02X:%02X:%02X:%02X:%02X:%02X",

--- a/src/host_tracker/host_tracker.h
+++ b/src/host_tracker/host_tracker.h
@@ -53,13 +53,13 @@ extern const uint8_t zero_mac[MAC_SIZE];
 
 struct HostMac
 {
-    HostMac(u_int8_t p_ttl, const u_int8_t* p_mac, u_int8_t p_primary, uint32_t p_last_seen)
+    HostMac(uint8_t p_ttl, const uint8_t* p_mac, uint8_t p_primary, uint32_t p_last_seen)
         : ttl(p_ttl), primary(p_primary), last_seen (p_last_seen) { memcpy(mac, p_mac, MAC_SIZE); }
 
     // the type and order below should match logger's serialization
-    u_int8_t ttl;
-    u_int8_t mac[MAC_SIZE];
-    u_int8_t primary;
+    uint8_t ttl;
+    uint8_t mac[MAC_SIZE];
+    uint8_t primary;
     uint32_t last_seen;
 };
 
@@ -98,7 +98,7 @@ public:
     }
 
     // Returns true if a new mac entry is added, false otherwise
-    bool add_mac(const u_int8_t* mac, u_int8_t ttl, u_int8_t primary);
+    bool add_mac(const uint8_t* mac, uint8_t ttl, uint8_t primary);
 
     // The caller owns and deletes the copied list of mac addresses
     void copy_data(uint8_t& p_hops, uint32_t& p_last_seen, std::list<HostMac>*& p_macs);

--- a/src/host_tracker/test/host_tracker_test.cc
+++ b/src/host_tracker/test/host_tracker_test.cc
@@ -81,7 +81,7 @@ TEST(host_tracker, copy_data_test)
 {
     test_time = 1562198400;
     HostTracker ht;
-    u_int8_t mac[6] = {254, 237, 222, 173, 190, 239};
+    uint8_t mac[6] = {254, 237, 222, 173, 190, 239};
     ht.add_mac(mac, 50, 1);
 
     uint8_t p_hops = 0;
@@ -107,8 +107,8 @@ TEST(host_tracker, stringify)
     test_time = 1562198400; // this time will be updated and should not be seen in stringify
     HostTracker ht;
 
-    u_int8_t mac1[6] = {254, 237, 222, 173, 190, 239};
-    u_int8_t mac2[6] = {202, 254, 192, 255, 238, 0};
+    uint8_t mac1[6] = {254, 237, 222, 173, 190, 239};
+    uint8_t mac2[6] = {202, 254, 192, 255, 238, 0};
     test_time = 1562198404; // this time should be the time of the first mac address
     ht.update_last_seen();
     ht.add_mac(mac1, 9, 0);

--- a/src/network_inspectors/rna/rna_logger.cc
+++ b/src/network_inspectors/rna/rna_logger.cc
@@ -36,7 +36,7 @@
 using namespace snort;
 
 bool RnaLogger::log(uint16_t type, uint16_t subtype, const Packet* p, RnaTracker* ht,
-    const struct in6_addr* src_ip, const u_int8_t* src_mac, uint32_t event_time,
+    const struct in6_addr* src_ip, const uint8_t* src_mac, uint32_t event_time,
     void* cond_var)
 {
     if ( !enabled )

--- a/src/network_inspectors/rna/rna_logger.h
+++ b/src/network_inspectors/rna/rna_logger.h
@@ -34,11 +34,11 @@ using RnaTracker = std::shared_ptr<snort::HostTracker>;
 struct RnaLoggerEvent : public Event
 {
     RnaLoggerEvent(uint16_t p_type, uint16_t p_subtype, const RnaTracker* p_ht,
-        const u_int8_t* p_mac) : type(p_type), subtype(p_subtype), ht(p_ht), mac(p_mac) { }
+        const uint8_t* p_mac) : type(p_type), subtype(p_subtype), ht(p_ht), mac(p_mac) { }
     uint16_t type;
     uint16_t subtype;
     const RnaTracker* ht;
-    const u_int8_t* mac;
+    const uint8_t* mac;
     const struct in6_addr* ip;
     void* cond_var = nullptr;
 };
@@ -48,7 +48,7 @@ class RnaLogger
 public:
     RnaLogger(const bool enable) : enabled(enable) { }
     bool log(uint16_t type, uint16_t subtype, const snort::Packet* p, RnaTracker* ht,
-       const struct in6_addr* src_ip, const u_int8_t* src_mac,
+       const struct in6_addr* src_ip, const uint8_t* src_mac,
        uint32_t event_time = 0, void* cond_var = nullptr);
 
 private:

--- a/src/network_inspectors/rna/rna_pnd.cc
+++ b/src/network_inspectors/rna/rna_pnd.cc
@@ -141,7 +141,7 @@ void RnaPnd::discover_network_udp(const Packet* p)
         discover_network(p, ip_api.ttl());
 }
 
-void RnaPnd::discover_network(const Packet* p, u_int8_t ttl)
+void RnaPnd::discover_network(const Packet* p, uint8_t ttl)
 {
     bool new_host = false;
     const auto& src_ip = p->ptrs.ip_api.get_src();

--- a/src/network_inspectors/rna/rna_pnd.h
+++ b/src/network_inspectors/rna/rna_pnd.h
@@ -62,7 +62,7 @@ private:
     void discover_network_non_ip(const snort::Packet* p);
     void discover_network_tcp(const snort::Packet* p);
     void discover_network_udp(const snort::Packet* p);
-    void discover_network(const snort::Packet* p, u_int8_t ttl);
+    void discover_network(const snort::Packet* p, uint8_t ttl);
 
     RnaLogger logger;
     DiscoveryFilter filter;


### PR DESCRIPTION
u_int8_t is not supported on musl so replace it by uint8_t

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>