### PR TITLE
cip_definitions.h: include <sys/time.h>

### DIFF
--- a/src/service_inspectors/cip/cip_definitions.h
+++ b/src/service_inspectors/cip/cip_definitions.h
@@ -23,6 +23,8 @@
 #ifndef CIP_DEFINITIONS_H
 #define CIP_DEFINITIONS_H
 
+#include <sys/time.h>
+
 namespace snort
 {
 struct Packet;


### PR DESCRIPTION
Fix build on musl by including <sys/time.h> to be able to use timeval

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>