### PR TITLE
Added release build capability to the configure script

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ Follow these steps:
     cd build
     make -j $(nproc) install
     ```
+   * To build a release image, you can configure it using the --build-type parameter as shown below.
+   ```shell
+   ./configure_cmake.sh --build-type=RelWithDebInfo --disable-memory-manager --disable-snort-profiler --disable-gdb
+   ```
 
 **_Note_**:
 

--- a/configure_cmake.sh
+++ b/configure_cmake.sh
@@ -20,6 +20,7 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
         --builddir=   The build directory
         --generator=  run cmake --help for a list of generators
         --prefix=     Snort++ installation prefix
+        --build-type= Build type e.g. Debug, Release, RelWithDebInfo
 
 Optional Features:
     --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
@@ -161,6 +162,9 @@ while [ $# -ne 0 ]; do
             ;;
         --generator=*)
             CMakeGenerator="$optarg"
+            ;;
+        --build-type=*)
+            CMakeBuildType="$optarg"
             ;;
         --prefix=*)
             prefix=$optarg
@@ -438,19 +442,26 @@ else
     mkdir -p $builddir
 fi
 
+if [ -z "$CMakeBuildType" ]; then
+    CMakeBuildType="Debug"
+fi
+
 echo "Build Directory : $builddir"
 echo "Source Directory: $sourcedir"
+echo "Building $CMakeBuildType Image"
 cd $builddir
 
-[ "$CMakeGenerator" ] && gen="-G $CMakeGenerator"
+"$CMakeGenerator" ] && gen="-G $CMakeGenerator"
 
 cmake "$gen" \
     -DCMAKE_CXX_FLAGS:STRING="$CXXFLAGS $CPPFLAGS" \
     -DCMAKE_C_FLAGS:STRING="$CFLAGS $CPPFLAGS" \
     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+    -DCMAKE_BUILD_TYPE=$CMakeBuildType \
     $CMakeCacheEntries $sourcedir
 
 echo "# This is the command used to configure this build" > config.status
 echo $command >> config.status
 chmod u+x config.status
+
 

--- a/configure_cmake.sh
+++ b/configure_cmake.sh
@@ -451,7 +451,7 @@ echo "Source Directory: $sourcedir"
 echo "Building $CMakeBuildType Image"
 cd $builddir
 
-"$CMakeGenerator" ] && gen="-G $CMakeGenerator"
+[ "$CMakeGenerator" ] && gen="-G $CMakeGenerator"
 
 cmake "$gen" \
     -DCMAKE_CXX_FLAGS:STRING="$CXXFLAGS $CPPFLAGS" \


### PR DESCRIPTION
Add the ability to specify cmake build type which would allow the user to build Debug or Release images (with optimizations turned on).

#### Tests Done on latest master from the snort++ repository:

`./configure_cmake.sh --build-type=RelWithDebInfo --disable-memory-manager --disable-snort-profiler --disable-gdb`

Verified -O2 is being added to the build
> src/service_inspectors/dce_rpc/CMakeFiles/dce_rpc.dir/dce_http_server_module.cc. cd snort3/build/src/service_inspectors/dce_rpc && /usr/bin/c++  -DHAVE_CONFIG_H -Dinline=inline -Drestrict=__restrict -Isnort3/src/network_inspectors -Isnort3/src -I/usr/include/luajit-2.1 -Isnort3/build -Isnort3 -I/usr/local/include -I/usr/include/uuid  -fvisibility=hidden   -DNDEBUG     **-O2** -g -DNDEBUG   -std=c++11 -o CMakeFiles/dce_rpc.dir/dce_http_server_module.cc.o -c snort3/src/service_inspectors/dce_rpc/dce_http_server_module.cc

Build succeeded 
`[100%] Built target snort_manuals`

#### Without the build-type parameter specified, Debug image is being built:
```shell
➜ ./configure_cmake.sh
Build Directory : build               
Source Directory: /home/dsounthi/Developer/repos/snort3
**Building Debug Image**
```
Now make does not have the -O2
> cd snort3/build/src/flow && /usr/bin/c++  -DHAVE_CONFIG_H -Dinline=inline -Drestrict=__restrict -Isnort3/src/network_inspectors -Isnort3/src -I/usr/include/luajit-2.1 -Isnort3/build -Isnort3 -I/usr/local/include -I/usr/include/uuid  -fvisibility=hidden   -DNDEBUG -g -ggdb    -g   -std=c++11 -o CMakeFiles/flow.dir/flow.cc.o -c snort3/src/flow/flow.cc 

