### PR TITLE
configure_cmake.sh: solve bug when --prefix contains a path with spaces

### DIFF
--- a/configure_cmake.sh
+++ b/configure_cmake.sh
@@ -173,7 +173,7 @@ while [ $# -ne 0 ]; do
             ;;
         --prefix=*)
             prefix="$optarg"
-            append_cache_entry CMAKE_INSTALL_PREFIX PATH $optarg
+            append_cache_entry CMAKE_INSTALL_PREFIX PATH "$optarg"
             ;;
         --enable-code-coverage)
             append_cache_entry ENABLE_CODE_COVERAGE     BOOL true

--- a/configure_cmake.sh
+++ b/configure_cmake.sh
@@ -172,7 +172,7 @@ while [ $# -ne 0 ]; do
             CMakeGenerator="$optarg"
             ;;
         --prefix=*)
-            prefix=$optarg
+            prefix="$optarg"
             append_cache_entry CMAKE_INSTALL_PREFIX PATH $optarg
             ;;
         --enable-code-coverage)


### PR DESCRIPTION
Solved bug when configure_cmake.sh received in the prefix option a path that contain some spaces. In such situation, configure_cmake.sh treat prefix value as 2 (or more) independent paths. 