### PR TITLE
Extend packet information in Lua alert module

### DIFF
--- a/src/loggers/alert_luajit.cc
+++ b/src/loggers/alert_luajit.cc
@@ -21,6 +21,7 @@
 #include "config.h"
 #endif
 
+#include "protocols/eth.h"
 #include "detection/ips_context.h"
 #include "detection/signature.h"
 #include "events/event.h"
@@ -81,6 +82,27 @@ SO_PUBLIC const SnortPacket* get_packet()
     lua_packet.num = packet->context->packet_number;
     lua_packet.sp = packet->ptrs.sp;
     lua_packet.dp = packet->ptrs.dp;
+
+    if ( !(packet->proto_bits & PROTO_BIT__ETH) ) {
+        lua_packet.ether_dst = lua_packet.ether_src = "";
+        return &lua_packet;
+    }
+
+    static char eth_src[20], eth_dst[20];
+
+    const eth::EtherHdr* eh = layer::get_eth_layer( packet );
+
+    snprintf(eth_src, 20, "%02X:%02X:%02X:%02X:%02X:%02X", eh->ether_src[0],
+        eh->ether_src[1], eh->ether_src[2], eh->ether_src[3],
+        eh->ether_src[4], eh->ether_src[5]);
+
+    lua_packet.ether_src = (const char*)eth_src;
+
+    snprintf(eth_dst, 20, "%02X:%02X:%02X:%02X:%02X:%02X", eh->ether_dst[0],
+        eh->ether_dst[1], eh->ether_dst[2], eh->ether_dst[3],
+        eh->ether_dst[4], eh->ether_dst[5]);
+
+    lua_packet.ether_dst = (const char*)eth_dst;
 
     return &lua_packet;
 }

--- a/src/loggers/alert_luajit.cc
+++ b/src/loggers/alert_luajit.cc
@@ -82,6 +82,7 @@ SO_PUBLIC const SnortPacket* get_packet()
     lua_packet.num = packet->context->packet_number;
     lua_packet.sp = packet->ptrs.sp;
     lua_packet.dp = packet->ptrs.dp;
+    lua_packet.dst_addr = "";
 
     if ( !(packet->proto_bits & PROTO_BIT__ETH) ) {
         lua_packet.ether_dst = lua_packet.ether_src = "";
@@ -103,6 +104,12 @@ SO_PUBLIC const SnortPacket* get_packet()
         eh->ether_dst[4], eh->ether_dst[5]);
 
     lua_packet.ether_dst = (const char*)eth_dst;
+
+    if ( packet->has_ip() or packet->is_data() ) {
+        static char ip[50];
+        packet->ptrs.ip_api.get_dst()->ntop(ip, 50);
+        lua_packet.dst_addr = ip;
+    }
 
     return &lua_packet;
 }

--- a/src/managers/lua_plugin_defs.h
+++ b/src/managers/lua_plugin_defs.h
@@ -50,13 +50,13 @@ const struct SnortEvent* get_event();
 
 struct SnortPacket
 {
-    // FIXIT-L add ip addrs and other useful foo to lua packet
     const char* type;
     uint64_t num;
     unsigned sp;
     unsigned dp;
     const char* ether_src;
     const char* ether_dst;
+    const char* dst_addr;
 };
 
 extern "C"

--- a/src/managers/lua_plugin_defs.h
+++ b/src/managers/lua_plugin_defs.h
@@ -55,6 +55,8 @@ struct SnortPacket
     uint64_t num;
     unsigned sp;
     unsigned dp;
+    const char* ether_src;
+    const char* ether_dst;
 };
 
 extern "C"


### PR DESCRIPTION
I'm playing with snort and I want to customize processing of alerts. The simplest way to do so seems to be writing Lua alert module. Unfortunately there seems to be some pieces of information missing and given there is TODO mentioned in source code to add those, I went ahead and added some. Tested locally and it seems to work.