### PR TITLE
Update the Timing Stats to More Precise Value

### DIFF
--- a/src/utils/stats.cc
+++ b/src/utils/stats.cc
@@ -138,9 +138,8 @@ static void timing_stats()
     TIMERSUB(&endtime, &starttime, &difftime);
 
     uint32_t tmp = (uint32_t)difftime.tv_sec;
-    uint32_t total_secs = tmp;
-    if ( total_secs < 1 )
-        total_secs = 1;
+    double total_secs = (double)tmp;
+    total_secs += (double)difftime.tv_usec/1000000.0;
 
     uint32_t hrs  = tmp / SECONDS_PER_HOUR;
     tmp  = tmp % SECONDS_PER_HOUR;
@@ -161,11 +160,11 @@ static void timing_stats()
     uint64_t num_pkts = (uint64_t)daq->get_global_count("analyzed");
     uint64_t num_byts = (uint64_t)daq->get_global_count("rx_bytes");
 
-    if ( uint64_t pps = (num_pkts / total_secs) )
-        LogMessage("%25.25s: " STDu64 "\n", "pkts/sec", pps);
+    if ( double pps = (num_pkts / total_secs) )
+        LogMessage("%25.25s: " STDu64 "\n", "pkts/sec", (uint64_t)pps);
 
-    if ( uint64_t mbps = 8 * num_byts / total_secs / 1024 / 1024 )
-        LogMessage("%25.25s: " STDu64 "\n", "Mbits/sec", mbps);
+    if ( double mbps = 8 * num_byts / total_secs / 1024 / 1024 )
+        LogMessage("%25.25s: " STDu64 "\n", "Mbits/sec", (uint64_t)mbps);
 }
 
 //-------------------------------------------------------------------------


### PR DESCRIPTION
Currently the timing statistics for total_secs just calculate
the secs part but omit the usecs part, so the final result shows
a big difference for pkt/s and Mbits/s, for example:

13.94 sec--> 13 secs
14.01 sec--> 14 secs

If the num_pkts and/or num_byts are great, the difference here between
2 tests seems to be great, but actually they are very close.

Now we made it more precisely here:
1. Adding the usecs value to sec part;
2. Using double type to calculate the whole performance by pkt/s and
mbits/s, then still choose the integer part as original and
omit the fractional part.

The final result is actually more acurate than original. In 1 of our jumbo packet
tests, we got a result from 636Mbit/s to 609Mbit/s after using the more 
acurate seconds value.

Signed-off-by: trevor tao <trevor.tao@arm.com>