### PR TITLE
Ips byte options update

### DIFF
--- a/src/framework/ips_option.cc
+++ b/src/framework/ips_option.cc
@@ -65,3 +65,82 @@ bool IpsOption::operator==(const IpsOption& ips) const
         !strcmp(get_buffer(), ips.get_buffer());
 }
 
+#ifdef UNIT_TEST
+#include "catch/snort_catch.h"
+
+
+
+class StubIpsOption : public IpsOption
+{
+public:
+    StubIpsOption(const char* name, option_type_t option_type) : 
+        IpsOption(name, option_type) 
+    { };
+
+};
+
+TEST_CASE("IpsOption test", "[ips_option]")
+{
+    StubIpsOption main_ips("ips_test", 
+        option_type_t::RULE_OPTION_TYPE_OTHER);
+    SECTION("IpsOperator== test")
+    {
+        StubIpsOption case_diff_name("not_hello_world", 
+        option_type_t::RULE_OPTION_TYPE_BUFFER_USE);
+        REQUIRE((main_ips==case_diff_name) == false);        
+        
+        StubIpsOption case_diff_option("hello_world", 
+        option_type_t::RULE_OPTION_TYPE_CONTENT);
+        REQUIRE((main_ips==case_diff_option) == false);        
+
+        StubIpsOption case_option_na("hello_world", 
+        option_type_t::RULE_OPTION_TYPE_OTHER); 
+        REQUIRE((main_ips==case_option_na) == false); 
+    } 
+
+    SECTION("hash test")
+    {
+        StubIpsOption main_ips("ips_test", 
+            option_type_t::RULE_OPTION_TYPE_OTHER);
+
+        SECTION("hash test with short string")
+        {
+            StubIpsOption main_ips_short("ips_test", 
+                option_type_t::RULE_OPTION_TYPE_OTHER);
+            REQUIRE((main_ips.hash() == main_ips_short.hash()) == true);
+
+            StubIpsOption main_ips_short_diff("not_ips_test", 
+                option_type_t::RULE_OPTION_TYPE_OTHER);
+            REQUIRE((main_ips.hash() == main_ips_short_diff.hash()) == false);
+        }
+
+        SECTION("hash test with long string")
+        { 
+            std::string really_long_string = 
+            "101010101010101010101010101010101010101010101010101010101010101" \
+            "101010101010101010101010101010101010101010101010101010101010101" \
+            "101010101010101010101010101010101010101010101010101010101010101" \
+            "101010101010101010101010101010101010101010101010101010101010101" \
+            "101010101010101010101010101010101010101010101010101010101010101" \
+            "101010101010101010101010101010101010101010101010101010101010101" \
+            "101010101010101010101010101010101010101010101010101010101010101" \
+            "101010101010101010101010101010101010101010101010101010101010101" \
+            "101010101010101010101010101010101010101010101010101010101010101" \
+            "101010101010101010101010101010101010101010101010101010101010101" \
+            "101010101010101010101010101010101010101010101010101010101010101" \
+            "101010101010101010101010101010101010101010101010101010101010101" \
+            "101010101010101010101010101010101010101010101010101010101010101";
+
+            StubIpsOption main_ips_long_first(really_long_string.c_str(), 
+                option_type_t::RULE_OPTION_TYPE_OTHER);
+            StubIpsOption main_ips_long_second(really_long_string.c_str(), 
+                option_type_t::RULE_OPTION_TYPE_OTHER);
+            REQUIRE((main_ips_long_first.hash() == main_ips_long_second.hash() 
+                == true));
+
+            REQUIRE((main_ips_long_first.hash() == main_ips.hash()) == false);    
+        }
+    } 
+}
+
+#endif

--- a/src/ips_options/extract.h
+++ b/src/ips_options/extract.h
@@ -22,6 +22,9 @@
 
 #include "main/thread.h"
 #include "main/snort_types.h"
+#include "framework/cursor.h"
+#include "framework/endianness.h"
+#include "protocols/packet.h"
 
 #define ENDIAN_BIG    0x1
 #define ENDIAN_LITTLE 0x2
@@ -36,6 +39,17 @@
 
 namespace snort
 {
+
+struct ExtractionSettings {
+    uint32_t bytes_to_extract;
+    int32_t offset;
+    bool relative_flag;
+    bool string_convert_flag;
+    uint8_t base;
+    uint8_t endianess;
+    uint32_t bitmask_val;
+};
+
 SO_PUBLIC int string_extract(
     int bytes_to_grab, int base, const uint8_t* ptr,
     const uint8_t* start, const uint8_t* end, uint32_t* value);
@@ -43,6 +57,16 @@ SO_PUBLIC int string_extract(
 SO_PUBLIC int byte_extract(
     int endianness, int bytes_to_grab, const uint8_t* ptr,
     const uint8_t* start, const uint8_t* end, uint32_t* value);
+
+SO_PUBLIC void set_cursor_bounds(const ExtractionSettings& settings, Cursor& c,
+    const uint8_t*& start, const uint8_t*& ptr, const uint8_t*& end);
+
+SO_PUBLIC int32_t data_extraction(const ExtractionSettings& settings, Packet* p,
+    uint32_t& result_var, const uint8_t*start, 
+    const uint8_t* ptr, const uint8_t* end);
+
+SO_PUBLIC int32_t extract_data(const ExtractionSettings& settings, Cursor& c, Packet* p,
+    uint32_t& result_var);
 
 SO_PUBLIC void set_byte_order(uint8_t& order, uint8_t flag, const char* opt);
 
@@ -59,4 +83,3 @@ SO_PUBLIC int GetVarValueByIndex(uint32_t* dst, uint8_t var_number);
 SO_PUBLIC int SetVarValueByIndex(uint32_t value, uint8_t var_number);
 }
 #endif
-

--- a/src/ips_options/ips_byte_extract.cc
+++ b/src/ips_options/ips_byte_extract.cc
@@ -35,6 +35,11 @@
 
 #include "extract.h"
 
+#ifdef UNIT_TEST
+#include "catch/snort_catch.h"
+#include "service_inspectors/dce_rpc/dce_common.h"
+#endif
+
 using namespace snort;
 
 static THREAD_LOCAL ProfileStats byteExtractPerfStats;
@@ -43,6 +48,7 @@ static THREAD_LOCAL ProfileStats byteExtractPerfStats;
 
 #define s_help \
     "rule option to convert data to an integer variable"
+
 
 struct ByteExtractData
 {
@@ -491,3 +497,804 @@ const BaseApi* ips_byte_extract[] =
     &byte_extract_api.base,
     nullptr
 };
+
+//-------------------------------------------------------------------------
+// UNIT TESTS
+//-------------------------------------------------------------------------
+#ifdef UNIT_TEST
+
+//-------------------------------------------------------------------------
+// helpers
+//-------------------------------------------------------------------------
+class ByteExtractDataMatcher
+    : public Catch::Matchers::Impl::MatcherBase<ByteExtractData>
+{
+   public:
+    ByteExtractDataMatcher(const ByteExtractData& value) : m_value(value) {}
+
+    bool match(ByteExtractData const& rhs) const override
+    {
+        return ((m_value.bytes_to_grab == rhs.bytes_to_grab) &&
+                (m_value.offset == rhs.offset) &&
+                (m_value.relative_flag == rhs.relative_flag) &&
+                (m_value.data_string_convert_flag == rhs.data_string_convert_flag) &&
+                (m_value.align == rhs.align) &&
+                (m_value.endianness == rhs.endianness) &&
+                (m_value.base == rhs.base) &&
+                (m_value.multiplier == rhs.multiplier) &&
+                (m_value.var_number == rhs.var_number) &&
+                (m_value.bitmask_val == rhs.bitmask_val));
+    }
+
+    std::string describe() const override
+    {
+        std::ostringstream ss;
+        ss << "settings is equals to:\n";
+        ss << "bytes_to_grab : " << m_value.bytes_to_grab << ";\n";
+        ss << "offset : " << m_value.offset << ";\n";
+        ss << "relative_flag : " << m_value.relative_flag << ";\n";
+        ss << "data_string_convert_flag : " << m_value.data_string_convert_flag << ";\n";
+        ss << "align : " << m_value.align << ";\n";
+        ss << "endianness : " << m_value.endianness << ";\n";
+        ss << "base : " << m_value.base << ";\n";
+        ss << "multiplier : " << m_value.multiplier << ";\n";
+        ss << "bitmask_val : " << m_value.bitmask_val << ";\n";
+        ss << "var_number : " << m_value.var_number << ";\n";
+        return ss.str();
+    }
+
+   private:
+    ByteExtractData m_value;
+};
+
+ByteExtractDataMatcher ByteExtractDataEquals(const ByteExtractData& value)
+{
+    return {value};
+}
+
+class SetBufferOptionHelper : public IpsOption
+{
+   public:
+    SetBufferOptionHelper(const char* value)
+        : IpsOption(value, RULE_OPTION_TYPE_BUFFER_SET)
+    {
+    }
+};
+
+//-------------------------------------------------------------------------
+// option tests
+//-------------------------------------------------------------------------
+
+TEST_CASE("ByteExtractOption::operator== valid", "[byte_extract_tests]")
+{
+    SetBufferOptionHelper set_buf("test");
+
+    char* lhs_name = new char[9];
+    strcpy(lhs_name, "test_lhs");
+    ByteExtractData data_lhs = {0, 0, 0, 0, 0, 0, 8, 1, 0, 0, lhs_name};
+    ByteExtractOption lhs(data_lhs);
+
+    char* rhs_name = new char[9];
+    strcpy(rhs_name, "test_rhs");
+    ByteExtractData data_rhs = {0, 0, 0, 0, 0, 0, 8, 1, 0, 0, rhs_name};
+    ByteExtractOption rhs(data_rhs);
+
+    CHECK(lhs == lhs);
+    CHECK(lhs == rhs);
+    CHECK(rhs == lhs);
+}
+
+TEST_CASE("ByteExtractOption::operator== invalid", "[byte_extract_tests]")
+{
+    SetBufferOptionHelper set_buf("test");
+
+    char* lhs_name = new char[5];
+    strcpy(lhs_name, "test");
+    ByteExtractData data_lhs = {0, 0, 0, 0, 0, 0, 0, 1, 0, 0};
+    ByteExtractOption lhs = (data_lhs);
+
+    SECTION("not equal to IpsOption object") { CHECK(!(lhs == set_buf)); }
+    SECTION("all fields is differ")
+    {
+        ByteExtractData data_rhs = {1, 4, true, false, 2, ENDIAN_FUNC,
+            0, 1, 0x1, 0, lhs_name};
+        ByteExtractOption rhs(data_rhs);
+        CHECK(!(lhs == rhs));
+        CHECK(!(rhs == lhs));
+    }
+    SECTION("bytes_to_grab is differ")
+    {
+        ByteExtractData data_rhs = {1, 0, 0, 0, 0, 0, 0, 1, 0, 0, lhs_name};
+        ByteExtractOption rhs(data_rhs);
+        CHECK(!(lhs == rhs));
+        CHECK(!(rhs == lhs));
+    }
+    SECTION("offset is differ")
+    {
+        ByteExtractData data_rhs = {0, 1, 0, 0, 0, 0, 0, 1, 0, 0, lhs_name};
+        ByteExtractOption rhs(data_rhs);
+        CHECK(!(lhs == rhs));
+        CHECK(!(rhs == lhs));
+    }
+    SECTION("relative_flag is differ")
+    {
+        ByteExtractData data_rhs = {0, 0, true, 0, 0, 0, 0, 1, 0, 0, lhs_name};
+        ByteExtractOption rhs(data_rhs);
+        CHECK(!(lhs == rhs));
+        CHECK(!(rhs == lhs));
+    }
+    SECTION("data_string_convert_flag is differ")
+    {
+        ByteExtractData data_rhs = {0, 0, 0, true, 0, 0, 0, 1, 0, 0, lhs_name};
+        ByteExtractOption rhs(data_rhs);
+        CHECK(!(lhs == rhs));
+        CHECK(!(rhs == lhs));
+    }
+    SECTION("align is differ")
+    {
+        ByteExtractData data_rhs = {0, 0, 0, 0, 2, 0, 0, 1, 0, 0, lhs_name};
+        ByteExtractOption rhs(data_rhs);
+        CHECK(!(lhs == rhs));
+        CHECK(!(rhs == lhs));
+    }
+    SECTION("endianness is differ")
+    {
+        ByteExtractData data_rhs = {0, 0, 0, 0, 0, ENDIAN_FUNC,
+            0, 1, 0, 0, lhs_name};
+        ByteExtractOption rhs(data_rhs);
+        CHECK(!(lhs == rhs));
+        CHECK(!(rhs == lhs));
+    }
+    SECTION("base is differ")
+    {
+        ByteExtractData data_rhs = {0, 0, 0, 0, 0, 0, 16, 1, 0, 0, lhs_name};
+        ByteExtractOption rhs(data_rhs);
+        CHECK(!(lhs == rhs));
+        CHECK(!(rhs == lhs));
+    }
+    SECTION("multiplier is differ")
+    {
+        ByteExtractData data_rhs = {0, 0, 0, 0, 0, 0, 0, 3, 0, 0, lhs_name};
+        ByteExtractOption rhs(data_rhs);
+        CHECK(!(lhs == rhs));
+        CHECK(!(rhs == lhs));
+    }
+    SECTION("bitmask is differ")
+    {
+        ByteExtractData data_rhs = {0, 0, 0, 0, 0, 0,
+            0, 1, 0xFFFF, 0, lhs_name};
+        ByteExtractOption rhs(data_rhs);
+        CHECK(!(lhs == rhs));
+        CHECK(!(rhs == lhs));
+    }
+    SECTION("var_number is differ")
+    {
+        ByteExtractData data_rhs = {0, 0, 0, 0, 0, 0, 0, 1, 0, 3, lhs_name};
+        ByteExtractOption rhs(data_rhs);
+        CHECK(!(lhs == rhs));
+        CHECK(!(rhs == lhs));
+    }
+    SECTION("name is differ")
+    {
+        char* rhs_name = new char[5];
+        strcpy(rhs_name, "tset");
+        ByteExtractData data_rhs = {0, 0, 0, 0, 0, 0, 0, 1, 0, 3, rhs_name};
+        ByteExtractOption rhs(data_rhs);
+        CHECK(!(lhs == rhs));
+        CHECK(!(rhs == lhs));
+    }
+}
+
+TEST_CASE("ByteExtractOption::hash", "[byte_extract_tests]")
+{
+    SetBufferOptionHelper set_buf("test");
+
+    ByteExtractData data_lhs = {0, 0, 0, 0, 0, 0, 8, 1, 0, 0};
+    ByteExtractOption lhs(data_lhs);
+
+    SECTION("hash codes of any two equal objects are equal")
+    {
+        ByteExtractData data_rhs = {0, 0, 0, 0, 0, 0, 8, 1, 0, 0};
+        ByteExtractOption rhs = (data_rhs);
+
+        CHECK(lhs.hash() == lhs.hash());
+        CHECK(lhs.hash() == rhs.hash());
+    }
+}
+
+TEST_CASE("ByteExtractOption::eval valid", "[byte_extract_tests]")
+{
+    Packet p;
+    p.data = (const uint8_t*)"Lorem 12345";
+    p.dsize = 11;
+    Cursor c(&p);
+
+    for (unsigned i = 0; i < NUM_IPS_OPTIONS_VARS; ++i)
+    {
+        SetVarValueByIndex(0, i);
+    }
+    ClearIpsOptionsVars();
+
+    char* name = new char[5];
+    strcpy(name, "test");
+
+    SECTION("1 byte read, all off")
+    {
+        ByteExtractData data = {1, 0, 0, 0, 0, ENDIAN_BIG, 0, 1, 0, 0, name};
+        ByteExtractOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 76);
+        CHECK(c.get_pos() == 1);
+    }
+    SECTION("1 byte read, offset 3")
+    {
+        ByteExtractData data = {1, 3, 0, 0, 0, ENDIAN_BIG, 0, 1, 0, 0, name};
+        ByteExtractOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 101);
+        CHECK(c.get_pos() == 4);
+    }
+    SECTION("1 byte read, offset 3, relative, cursor 3")
+    {
+        ByteExtractData data = {1, 3, 1, 0, 0, ENDIAN_BIG, 0, 1, 0, 0, name};
+        ByteExtractOption opt(data);
+        c.set_pos(3);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 49);
+        CHECK(c.get_pos() == 7);
+    }
+    SECTION("1 byte read, offset -3, relative, cursor 3")
+    {
+        ByteExtractData data = {1, -3, 1, 0, 0, ENDIAN_BIG, 0, 1, 0, 0, name};
+        ByteExtractOption opt(data);
+        c.set_pos(3);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 76);
+        CHECK(c.get_pos() == 1);
+    }
+    SECTION("1 byte read, offset 6, string conv, base 10")
+    {
+        ByteExtractData data = {1, 6, 0, 1, 0, ENDIAN_BIG, 10, 1, 0, 0, name};
+        ByteExtractOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 1);
+        CHECK(c.get_pos() == 7);
+    }
+    SECTION("1 byte read, offset 6, string conv, base 10, align 2")
+    {
+        ByteExtractData data = {1, 6, 0, 1, 2, ENDIAN_BIG, 10, 1, 0, 0, name};
+        ByteExtractOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 2);
+        CHECK(c.get_pos() == 7);
+    }
+    SECTION("3 byte read, offset 6, string conv, base 10, align 4")
+    {
+        ByteExtractData data = {3, 6, 0, 1, 4, ENDIAN_BIG, 10, 1, 0, 0, name};
+        ByteExtractOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 124);
+        CHECK(c.get_pos() == 9);
+    }
+    SECTION("1 byte read, offset 1, no string conv, align 2, mult 3")
+    {
+        ByteExtractData data = {1, 1, 0, 0, 2, ENDIAN_BIG, 0, 3, 0, 0, name};
+        ByteExtractOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 334);
+        CHECK(c.get_pos() == 2);
+    }
+    SECTION("1 byte read, offset 3, no string conv, align 4, mult 5")
+    {
+        ByteExtractData data = {1, 3, 0, 0, 4, ENDIAN_BIG, 0, 5, 0, 0, name};
+        ByteExtractOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 508);
+        CHECK(c.get_pos() == 4);
+    }
+    SECTION("1 byte read, offset 6, string conv, base 10, mult 7")
+    {
+        ByteExtractData data = {1, 6, 0, 1, 0, ENDIAN_BIG, 10, 7, 0, 0, name};
+        ByteExtractOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 7);
+        CHECK(c.get_pos() == 7);
+    }
+    SECTION("2 byte read, bitmask 1100110011100011")
+    {
+        ByteExtractData data = {2, 0, 0, 0, 0, ENDIAN_BIG, 0, 1, 52451, 0, name};
+        ByteExtractOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 19555);
+        CHECK(c.get_pos() == 2);
+    }
+    SECTION("2 byte read, bitmask 1100110011100000")
+    {
+        ByteExtractData data = {2, 0, 0, 0, 0, ENDIAN_BIG, 0, 1, 52448, 0, name};
+        ByteExtractOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 611);
+        CHECK(c.get_pos() == 2);
+    }
+    SECTION("4 bytes read, ENDIAN_LITTLE")
+    {
+        ByteExtractData data = {4, 0, 0, 0, 0, ENDIAN_LITTLE, 0, 1, 0, 0, name};
+        ByteExtractOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 1701998412);
+        CHECK(c.get_pos() == 4);
+    }
+    SECTION(
+        "4 bytes read, ENDIAN_FUNC, packet.endianness = "
+        "DCERPC_BO_FLAG__LITTLE_ENDIAN")
+    {
+        DceEndianness* auto_endian = new DceEndianness();
+        auto_endian->hdr_byte_order = DCERPC_BO_FLAG__LITTLE_ENDIAN;
+        auto_endian->data_byte_order = DCERPC_BO_FLAG__LITTLE_ENDIAN;
+        p.endianness = auto_endian;
+        ByteExtractData data = {4, 0, 0, 0, 0, ENDIAN_FUNC, 0, 1, 0, 0, name};
+        ByteExtractOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 1701998412);
+        CHECK(c.get_pos() == 4);
+    }
+}
+
+TEST_CASE("ByteExtractOption::eval invalid", "[byte_extract_tests]")
+{
+    Packet p;
+    p.data = (const uint8_t*)"Lorem 9876";
+    p.dsize = 11;
+    Cursor c(&p);
+
+    for (unsigned i = 0; i < NUM_IPS_OPTIONS_VARS; ++i)
+    {
+        SetVarValueByIndex(0, i);
+    }
+    ClearIpsOptionsVars();
+
+    char* name = new char[5];
+    strcpy(name, "test");
+
+    SECTION("packet = nullptr")
+    {
+        ByteExtractData data = {1, 6, 0, 0, 0, ENDIAN_BIG, 0, 1, 0, 0, name};
+        ByteExtractOption opt(data);
+        CHECK(opt.eval(c, nullptr) == IpsOption::NO_MATCH);
+    }
+    SECTION("read more than 4 bytes")
+    {
+        ByteExtractData data = {6, 0, 0, 0, 0, ENDIAN_BIG, 0, 1, 0, 0, name};
+        ByteExtractOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::NO_MATCH);
+        CHECK(c.get_pos() == 0);
+    }
+    SECTION("check bounds of packet, offset > packet size")
+    {
+        ByteExtractData data = {1, 20, 0, 0, 0, ENDIAN_BIG, 0, 1, 0, 0, name};
+        ByteExtractOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::NO_MATCH);
+        CHECK(c.get_pos() == 0);
+    }
+    SECTION("negative offset, without relative flag")
+    {
+        ByteExtractData data = {1, -20, 0, 0, 0, ENDIAN_BIG, 0, 1, 0, 0, name};
+        ByteExtractOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::NO_MATCH);
+        CHECK(c.get_pos() == 0);
+    }
+    SECTION("negative offset, out of bounds")
+    {
+        ByteExtractData data = {1, -20, 1, 0, 0, ENDIAN_BIG, 0, 1, 0, 0, name};
+        ByteExtractOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::NO_MATCH);
+        CHECK(c.get_pos() == 0);
+    }
+    SECTION("check bounds of packet, read 2 bytes, empty packet")
+    {
+        p.data = (const uint8_t*)"";
+        p.dsize = 0;
+        Cursor c2(&p);
+        ByteExtractData data = {2, 0, 0, 0, 0, ENDIAN_BIG, 0, 1, 0, 0, name};
+        ByteExtractOption opt(data);
+        CHECK(opt.eval(c2, &p) == IpsOption::NO_MATCH);
+        CHECK(c2.get_pos() == 0);
+    }
+    SECTION("align value to 1")
+    {
+        ByteExtractData data = {1, 0, 0, 0, 1, ENDIAN_BIG, 0, 1, 0, 0, name};
+        ByteExtractOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 76);
+        CHECK(c.get_pos() == 1);
+    }
+    SECTION("align value to 6")
+    {
+        ByteExtractData data = {1, 0, 0, 0, 6, ENDIAN_BIG, 0, 1, 0, 0, name};
+        ByteExtractOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 76);
+        CHECK(c.get_pos() == 1);
+    }
+    SECTION("ENDIAN_FUNC, without definition of endianness in packet")
+    {
+        ByteExtractData data = {3, 0, 0, 0, 0, ENDIAN_FUNC, 0, 1, 0, 0, name};
+        ByteExtractOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::NO_MATCH);
+        CHECK(c.get_pos() == 0);
+    }
+    SECTION("conversion from string, decimal number, base = 8")
+    {
+        ByteExtractData data = {3, 6, 0, 1, 0, ENDIAN_BIG, 8, 1, 0, 0, name};
+        ByteExtractOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::NO_MATCH);
+        CHECK(c.get_pos() == 0);
+    }
+}
+
+//-------------------------------------------------------------------------
+// module tests
+//-------------------------------------------------------------------------
+
+TEST_CASE("ExtractModule lifecycle", "[byte_extract_tests]")
+{
+    ExtractModule obj;
+
+    SECTION("test of constructor") { CHECK(obj.data.multiplier == 1); }
+    SECTION("test of \"begin\" method")
+    {
+        CHECK(obj.begin(nullptr, 0, nullptr));
+        ByteExtractData expected = {0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0};
+
+        CHECK_THAT(obj.data, ByteExtractDataEquals(expected));
+    }
+    SECTION("test of \"end\" method")
+    {
+        obj.begin(nullptr, 0, nullptr);
+
+        Value v_name("test");
+        Parameter p_name = {
+            "~name", Parameter::PT_STRING, nullptr, nullptr,
+            "name of the variable that will be used in other rule options"};
+        v_name.set(&p_name);
+        obj.set(nullptr, v_name, nullptr);
+
+        Value v_bytes(4.0);
+        Parameter p_bytes = {"~count", Parameter::PT_INT, "1:10", nullptr,
+            "number of bytes to pick up from the buffer"};
+        v_bytes.set(&p_bytes);
+        obj.set(nullptr, v_bytes, nullptr);
+
+        CHECK(obj.end(nullptr, 0, nullptr));
+
+        char* name = new char[5];
+        strcpy(name, "test");
+        ByteExtractData expected = {4, 0, 0, 0, 0, ENDIAN_BIG,
+            0, 1, 0, 0, name};
+
+        CHECK_THAT(obj.data, ByteExtractDataEquals(expected));
+
+        delete name;
+    }
+}
+
+TEST_CASE("Test of byte_extract_ctor", "[byte_extract_tests]")
+{
+    ClearIpsOptionsVars();
+
+    std::string name = "test";
+    for (unsigned i = 0; i <= NUM_IPS_OPTIONS_VARS; ++i)
+    {
+        ExtractModule obj;
+        obj.begin(nullptr, 0, nullptr);
+        Value v((name + std::to_string(i)).c_str());
+        Parameter p = {"~name", Parameter::PT_STRING, nullptr, nullptr,
+            "name of the variable that will be used in other rule options"};
+        v.set(&p);
+        obj.set(nullptr, v, nullptr);
+        if (i < NUM_IPS_OPTIONS_VARS)
+        {
+            IpsOption* res = byte_extract_ctor(&obj, nullptr);
+            delete res;
+        }
+        else
+        {
+            IpsOption* res_null = byte_extract_ctor(&obj, nullptr);
+            CHECK(res_null == nullptr);
+        }
+    }
+}
+
+TEST_CASE("ExtractModule::set", "[byte_extract_tests]")
+{
+    ExtractModule obj;
+    obj.begin(nullptr, 0, nullptr);
+
+    SECTION("set bytes_to_grab")
+    {
+        Value v(4.0);
+        Parameter p = {"~count", Parameter::PT_INT, "1:10", nullptr,
+            "number of bytes to pick up from the buffer"};
+        v.set(&p);
+        ByteExtractData expected = {4, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0};
+
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data, ByteExtractDataEquals(expected));
+    }
+    SECTION("set offset")
+    {
+        Value v(7.0);
+        Parameter p = {"~offset", Parameter::PT_INT, "-65535:65535", nullptr,
+            "number of bytes into the buffer to start processing"};
+        v.set(&p);
+        ByteExtractData expected = {0, 7, 0, 0, 0, 0, 0, 1, 0, 0, 0};
+
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data, ByteExtractDataEquals(expected));
+    }
+    SECTION("set name")
+    {
+        Value v("test_name");
+        Parameter p = {"~name", Parameter::PT_STRING, nullptr, nullptr,
+            "name of the variable that will be used in other rule options"};
+        v.set(&p);
+
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data.name, Catch::Matchers::Equals("test_name"));
+    }
+    SECTION("set relative")
+    {
+        Value v(true);
+        Parameter p = {"relative", Parameter::PT_IMPLIED, nullptr, nullptr,
+            "offset from cursor instead of start of buffer"};
+        v.set(&p);
+        obj.set(nullptr, v, nullptr);
+        ByteExtractData expected = {0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0};
+
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data, ByteExtractDataEquals(expected));
+    }
+    SECTION("set multiplier")
+    {
+        Value v(6.0);
+        Parameter p = {"multiplier", Parameter::PT_INT, "1:65535", "1",
+            "scale extracted value by given amount"};
+        v.set(&p);
+        ByteExtractData expected = {0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0};
+
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data, ByteExtractDataEquals(expected));
+    }
+    SECTION("set align")
+    {
+        Value v(2.0);
+        Parameter p = {"align", Parameter::PT_INT, "0:4", "0",
+            "round the number of converted bytes up to the next 2- "
+            "or 4-byte boundary"};
+        v.set(&p);
+        ByteExtractData expected = {0, 0, 0, 0, 2, 0, 0, 1, 0, 0, 0};
+
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data, ByteExtractDataEquals(expected));
+    }
+    SECTION("set endianness")
+    {
+        Value v_big((double)ENDIAN_BIG);
+        Parameter p_big = {"big", Parameter::PT_IMPLIED, nullptr, nullptr,
+            "big endian"};
+        v_big.set(&p_big);
+        obj.set(nullptr, v_big, nullptr);
+        ByteExtractData expected_big = {0, 0, 0, 0, 0, ENDIAN_BIG,
+            0, 1, 0, 0, 0};
+        CHECK(obj.set(nullptr, v_big, nullptr));
+        CHECK_THAT(obj.data, ByteExtractDataEquals(expected_big));
+
+        Value v_lit((double)ENDIAN_LITTLE);
+        Parameter p_lit = {"little", Parameter::PT_IMPLIED, nullptr, nullptr,
+            "little endian"};
+        v_lit.set(&p_lit);
+        ByteExtractData expected_lit = {0, 0, 0, 0, 0, ENDIAN_LITTLE,
+            0, 1, 0, 0, 0};
+        CHECK(obj.set(nullptr, v_lit, nullptr));
+        CHECK_THAT(obj.data, ByteExtractDataEquals(expected_lit));
+
+        Value v_dce((double)ENDIAN_FUNC);
+        Parameter p_dce = {"dce", Parameter::PT_IMPLIED, nullptr, nullptr,
+            "dcerpc2 determines endianness"};
+        v_dce.set(&p_dce);
+        ByteExtractData expected_dce = {0, 0, 0, 0, 0, ENDIAN_FUNC,
+            0, 1, 0, 0, 0};
+        CHECK(obj.set(nullptr, v_dce, nullptr));
+        CHECK_THAT(obj.data, ByteExtractDataEquals(expected_dce));
+    }
+    SECTION("set string")
+    {
+        Value v(true);
+        Parameter p = {"string", Parameter::PT_IMPLIED, nullptr, nullptr,
+            "convert from string"};
+        v.set(&p);
+        ByteExtractData expected = {0, 0, 0, 1, 0, 0, 10, 1, 0, 0, 0};
+
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data, ByteExtractDataEquals(expected));
+    }
+    SECTION("set hex")
+    {
+        Value v(true);
+        Parameter p = {"hex", Parameter::PT_IMPLIED, nullptr, nullptr,
+            "convert from hex string"};
+        v.set(&p);
+        ByteExtractData expected = {0, 0, 0, 0, 0, 0, 16, 1, 0, 0, 0};
+
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data, ByteExtractDataEquals(expected));
+    }
+    SECTION("set oct")
+    {
+        Value v(true);
+        Parameter p = {"oct", Parameter::PT_IMPLIED, nullptr, nullptr,
+            "convert from octal string"};
+        v.set(&p);
+        ByteExtractData expected = {0, 0, 0, 0, 0, 0, 8, 1, 0, 0, 0};
+
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data, ByteExtractDataEquals(expected));
+    }
+    SECTION("set dec")
+    {
+        Value v(true);
+        Parameter p = {"dec", Parameter::PT_IMPLIED, nullptr, nullptr,
+            "convert from decimal string"};
+        v.set(&p);
+        ByteExtractData expected = {0, 0, 0, 0, 0, 0, 10, 1, 0, 0, 0};
+
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data, ByteExtractDataEquals(expected));
+    }
+    SECTION("set bitmask")
+    {
+        Value v(1023.0);
+        Parameter p = {"bitmask", Parameter::PT_INT, "0x1:0xFFFFFFFF", nullptr,
+            "applies as an AND to the extracted value before "
+            "storage in 'name'"};
+        v.set(&p);
+        ByteExtractData expected = {0, 0, 0, 0, 0, 0, 0, 1, 1023, 0, 0};
+
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data, ByteExtractDataEquals(expected));
+    }
+    SECTION("invalid set")
+    {
+        Value v(1023.0);
+        Parameter p = {"error", Parameter::PT_INT, "nan", nullptr,
+            "not an option"};
+        v.set(&p);
+        ByteExtractData expected = {0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0};
+
+        CHECK(!obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data, ByteExtractDataEquals(expected));
+    }
+}
+
+//-------------------------------------------------------------------------
+// api tests
+//-------------------------------------------------------------------------
+
+TEST_CASE("ByteExtractVerify_valid", "[byte_extract_tests]")
+{
+    ByteExtractData obj;
+    char* name = new char[5];
+    strcpy(name, "test");
+
+    SECTION("Minimum values, no string convertion")
+    {
+        obj = {1, -65535, 1, 0, 0, ENDIAN_FUNC, 0, 1, 0x1, 0, name};
+        CHECK(ByteExtractVerify(&obj));
+    }
+    SECTION("Maximum values, no string convertion")
+    {
+        obj = {MAX_BYTES_TO_GRAB, 65535, 1, 0, 4, ENDIAN_FUNC, 0, 65535,
+            0xFFFFFFFF, 0, name};
+        CHECK(ByteExtractVerify(&obj));
+    }
+
+    SECTION("Minimum values, with string convertion")
+    {
+        obj = {1, -65535, 1, 1, 0, ENDIAN_FUNC, 8, 1, 0x1, 0, name};
+        CHECK(ByteExtractVerify(&obj));
+    }
+    SECTION("Maximum values, with string convertion")
+    {
+        obj = {PARSELEN, 65535, 1, 1, 4, ENDIAN_FUNC,
+            16, 65535, 0xFFFFFFFF, 0, name};
+        CHECK(ByteExtractVerify(&obj));
+    }
+    delete name;
+}
+
+TEST_CASE("ByteExtractVerify_invalid", "[byte_extract_tests]")
+{
+    char* name = new char[5];
+    strcpy(name, "test");
+    ByteExtractData obj = {2, 7, 0, 0, 2, ENDIAN_FUNC, 0, 1, 0, 0, name};
+
+    SECTION("bytes_to_grab checks")
+    {
+        obj.bytes_to_grab = MAX_BYTES_TO_GRAB + 1;
+        CHECK((!ByteExtractVerify(&obj)));
+
+        obj.data_string_convert_flag = true;
+        obj.bytes_to_grab = PARSELEN + 1;
+        CHECK((!ByteExtractVerify(&obj)));
+    }
+    SECTION("align checks")
+    {
+        obj.align = 1;
+        CHECK((!ByteExtractVerify(&obj)));
+
+        obj.align = 6;
+        CHECK((!ByteExtractVerify(&obj)));
+    }
+    SECTION("offset checks")
+    {
+        obj.offset = -5;
+        CHECK((!ByteExtractVerify(&obj)));
+    }
+    SECTION("name checks")
+    {
+        delete name;
+        obj.name = nullptr;
+        CHECK((!ByteExtractVerify(&obj)));
+
+        name = new char[6];
+        strcpy(name, "9test");
+        obj.name = name;
+        CHECK((!ByteExtractVerify(&obj)));
+    }
+    SECTION("base checks")
+    {
+        obj.base = 16;
+        CHECK((!ByteExtractVerify(&obj)));
+    }
+    SECTION("bitmask checks")
+    {
+        obj.bytes_to_grab = 2;
+        obj.bitmask_val = 1048575;
+        CHECK((!ByteExtractVerify(&obj)));
+    }
+    delete name;
+}
+
+#endif

--- a/src/ips_options/ips_byte_math.cc
+++ b/src/ips_options/ips_byte_math.cc
@@ -36,6 +36,11 @@
 
 #include "extract.h"
 
+#ifdef UNIT_TEST
+#include "catch/snort_catch.h"
+#include "service_inspectors/dce_rpc/dce_common.h"
+#endif
+
 using namespace snort;
 using namespace std;
 
@@ -575,3 +580,1050 @@ const BaseApi* ips_byte_math[] =
     &byte_math_api.base,
     nullptr
 };
+
+//-------------------------------------------------------------------------
+// UNIT TESTS
+//-------------------------------------------------------------------------
+#ifdef UNIT_TEST
+
+//-------------------------------------------------------------------------
+// helpers
+//-------------------------------------------------------------------------
+class ByteMathDataMatcher
+    : public Catch::Matchers::Impl::MatcherBase<ByteMathData>
+{
+   public:
+    ByteMathDataMatcher(const ByteMathData& value) : m_value(value) {}
+
+    bool match(ByteMathData const& rhs) const override
+    {
+        return ((m_value.bytes_to_extract == rhs.bytes_to_extract) &&
+                (m_value.rvalue == rhs.rvalue) && (m_value.oper == rhs.oper) &&
+                (m_value.offset == rhs.offset) &&
+                (m_value.relative_flag == rhs.relative_flag) &&
+                (m_value.string_convert_flag == rhs.string_convert_flag) &&
+                (m_value.endianess == rhs.endianess) &&
+                (m_value.base == rhs.base) &&
+                (m_value.bitmask_val == rhs.bitmask_val) &&
+                (m_value.rvalue_var == rhs.rvalue_var) &&
+                (m_value.offset_var == rhs.offset_var) &&
+                (m_value.result_var == rhs.result_var));
+    }
+
+    std::string describe() const override
+    {
+        std::ostringstream ss;
+        ss << "settings is equals to:\n";
+        ss << "bytes_to_extract : " << m_value.bytes_to_extract << ";\n";
+        ss << "rvalue : " << m_value.rvalue << ";\n";
+        ss << "oper : " << m_value.oper << ";\n";
+        ss << "offset : " << m_value.offset << ";\n";
+        ss << "relative_flag : " << m_value.relative_flag << ";\n";
+        ss << "string_convert_flag : " << m_value.string_convert_flag << ";\n";
+        ss << "endianess : " << m_value.endianess << ";\n";
+        ss << "base : " << m_value.base << ";\n";
+        ss << "bitmask_val : " << m_value.bitmask_val << ";\n";
+        ss << "rvalue_var : " << m_value.rvalue_var << ";\n";
+        ss << "offset_var : " << m_value.offset_var << ";\n";
+        ss << "result_var : " << m_value.result_var << ";\n";
+        return ss.str();
+    }
+
+   private:
+    ByteMathData m_value;
+};
+
+ByteMathDataMatcher ByteMathDataEquals(const ByteMathData& value)
+{
+    return {value};
+}
+
+class SetBufferOptionHelper : public IpsOption
+{
+   public:
+    SetBufferOptionHelper(const char* value)
+        : IpsOption(value, RULE_OPTION_TYPE_BUFFER_SET)
+    {
+    }
+};
+
+//-------------------------------------------------------------------------
+// option tests
+//-------------------------------------------------------------------------
+
+TEST_CASE("ByteMathOption::operator== valid", "[byte_math_tests]")
+{
+    SetBufferOptionHelper set_buf("test");
+
+    char* lhs_name = new char[9];
+    strcpy(lhs_name, "test_lhs");
+    ByteMathData data_lhs = {0,25, 0, 0, lhs_name, BM_PLUS, 0, 0, 0, ENDIAN_BIG,
+    IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+    ByteMathOption lhs(data_lhs);
+
+    char* rhs_name = new char[9];
+    strcpy(rhs_name, "test_rhs");
+    ByteMathData data_rhs = {0, 25, 0, 0, rhs_name, BM_PLUS, 0, 0, 0, ENDIAN_BIG,
+        IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+    ByteMathOption rhs(data_rhs);
+
+    CHECK(lhs == lhs);
+    CHECK(lhs == rhs);
+    CHECK(rhs == lhs);
+}
+
+TEST_CASE("ByteMathOption::operator== invalid", "[byte_math_tests]")
+{
+    SetBufferOptionHelper set_buf("test");
+
+    char* lhs_name = new char[5];
+    strcpy(lhs_name, "test");
+    ByteMathData data_lhs = {0, 25, 0, 0, lhs_name, BM_PLUS, 0, 0, 0, ENDIAN_BIG, 
+        IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+    ByteMathOption lhs = (data_lhs);
+
+    char* rhs_name = new char[5];
+    strcpy(rhs_name, "test");
+
+    SECTION("not equal to IpsOption object") { CHECK(!(lhs == set_buf)); }
+    SECTION("all fields is differ")
+    {
+        delete rhs_name;
+        char* rhs_name = new char[5];
+        strcpy(rhs_name, "tset");
+        ByteMathData data_rhs = {2, 25, 2, 255, rhs_name, BM_MULTIPLY, 1,  
+            1, 8, ENDIAN_LITTLE, 1, 1, 1};
+        ByteMathOption rhs(data_rhs);
+        CHECK(!(lhs == rhs));
+        CHECK(!(rhs == lhs));
+    }
+    SECTION("bytes_to_grab is differ")
+    {
+        ByteMathData data_rhs = {2, 25, 0, 0, rhs_name, BM_PLUS, 0, 0, 0, ENDIAN_BIG,
+            IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption rhs(data_rhs);
+        CHECK(!(lhs == rhs));
+        CHECK(!(rhs == lhs));
+    }
+    SECTION("rvalue is differ")
+    {
+        ByteMathData data_rhs = {0, 15, 0, 0, rhs_name, BM_PLUS, 0, 0, 0, ENDIAN_BIG,
+            IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption rhs(data_rhs);
+        CHECK(!(lhs == rhs));
+        CHECK(!(rhs == lhs));
+    }
+    SECTION("offset is differ")
+    {
+        ByteMathData data_rhs = {0, 25, 3, 0, rhs_name, BM_PLUS, 0, 0, 0, ENDIAN_BIG,
+            IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption rhs(data_rhs);
+        CHECK(!(lhs == rhs));
+        CHECK(!(rhs == lhs));
+    }
+    SECTION("bitmask is differ")
+    {
+        ByteMathData data_rhs = {0, 25, 0, 255, rhs_name, BM_PLUS, 0, 0, 0, ENDIAN_BIG,
+            IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption rhs(data_rhs);
+        CHECK(!(lhs == rhs));
+        CHECK(!(rhs == lhs));
+    }
+    SECTION("result_name is differ")
+    {
+        delete rhs_name;
+        char* rhs_name = new char[5];
+        strcpy(rhs_name, "tset");
+        ByteMathData data_rhs = {0, 25, 0, 255, rhs_name, BM_PLUS, 0, 0, 0, ENDIAN_BIG,
+            IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption rhs(data_rhs);
+        CHECK(!(lhs == rhs));
+        CHECK(!(rhs == lhs));
+    }
+    SECTION("operation is differ")
+    {
+        ByteMathData data_rhs = {0, 25, 0, 0, rhs_name, BM_DIVIDE, 0, 0, 0, ENDIAN_BIG,
+            IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption rhs(data_rhs);
+        CHECK(!(lhs == rhs));
+        CHECK(!(rhs == lhs));
+    }
+    SECTION("relative_flag is differ")
+    {
+        ByteMathData data_rhs = {0, 25, 0, 0, rhs_name, BM_PLUS, 1, 0, 0, ENDIAN_BIG,
+            IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption rhs(data_rhs);
+        CHECK(!(lhs == rhs));
+        CHECK(!(rhs == lhs));
+    }
+    SECTION("string_convert_flag is differ")
+    {
+        ByteMathData data_rhs = {0, 25, 0, 0, rhs_name, BM_PLUS, 0, 1, 0, ENDIAN_BIG,
+            IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption rhs(data_rhs);
+        CHECK(!(lhs == rhs));
+        CHECK(!(rhs == lhs));
+    }
+    SECTION("base is differ")
+    {
+        ByteMathData data_rhs = {0, 25, 0, 0, rhs_name, BM_PLUS, 0, 0, 8, ENDIAN_BIG,
+            IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption rhs(data_rhs);
+        CHECK(!(lhs == rhs));
+        CHECK(!(rhs == lhs));
+    }
+    SECTION("endianess is differ")
+    {
+        ByteMathData data_rhs = {0, 25, 0, 0, rhs_name, BM_PLUS, 0, 0, 0, ENDIAN_LITTLE,
+            IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption rhs(data_rhs);
+        CHECK(!(lhs == rhs));
+        CHECK(!(rhs == lhs));
+    }
+    SECTION("result_var is differ")
+    {
+        ByteMathData data_rhs = {0, 25, 0, 0, rhs_name, BM_PLUS, 0, 0, 0,  ENDIAN_BIG, 
+            0, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption rhs(data_rhs);
+        CHECK(!(lhs == rhs));
+        CHECK(!(rhs == lhs));
+    }
+    SECTION("rvalue_var is differ")
+    {
+        ByteMathData data_rhs = {0, 25, 0, 0, rhs_name, BM_PLUS, 0, 0, 0, ENDIAN_BIG,
+            IPS_OPTIONS_NO_VAR, 1, IPS_OPTIONS_NO_VAR};
+        ByteMathOption rhs(data_rhs);
+        CHECK(!(lhs == rhs));
+        CHECK(!(rhs == lhs));
+    }
+    SECTION("offset_var is differ")
+    {
+        ByteMathData data_rhs = {0, 25, 0, 0, rhs_name, BM_PLUS, 0, 0,  0, ENDIAN_BIG,
+            IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR, 0};
+        ByteMathOption rhs(data_rhs);
+        CHECK(!(lhs == rhs));
+        CHECK(!(rhs == lhs));
+    }
+}
+
+TEST_CASE("ByteMathOption::hash", "[byte_math_tests]")
+{
+    SetBufferOptionHelper set_buf("test");
+
+    char* lhs_name = new char[5];
+    strcpy(lhs_name, "test");
+    ByteMathData data_lhs = {2, 25, 2, 255, lhs_name, BM_MULTIPLY, 1, 1, 8,
+        ENDIAN_LITTLE, 1, 1, 1};
+    ByteMathOption lhs(data_lhs);
+
+    SECTION("hash codes of any two equal objects are equal")
+    {
+        char* rhs_name = new char[5];
+        strcpy(rhs_name, "test");
+        ByteMathData data_rhs = {2, 25, 2, 255, rhs_name, BM_MULTIPLY, 1, 1, 8,
+            ENDIAN_LITTLE, 1, 1,  1};
+        ByteMathOption rhs = (data_rhs);
+
+        CHECK(lhs.hash() == lhs.hash());
+        CHECK(lhs.hash() == rhs.hash());
+    }
+}
+
+TEST_CASE("ByteMathOption::eval valid", "[byte_math_tests]")
+{
+    Packet p;
+    p.data = (const uint8_t*)"Lorem 12345";
+    p.dsize = 11;
+    Cursor c(&p);
+
+    for (unsigned i = 0; i < NUM_IPS_OPTIONS_VARS; ++i)
+    {
+        SetVarValueByIndex(0, i);
+    }
+    ClearIpsOptionsVars();
+
+    char* name = new char[5];
+    strcpy(name, "test");
+
+    SECTION("1 byte read, all off, operation \"+\", rvalue 1")
+    {
+        ByteMathData data = {1, 1, 0, 0, name, BM_PLUS, 0, 0, 0, 
+            ENDIAN_BIG, 0, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 77);
+    }
+    SECTION("1 byte read, offset 3, operation \"*\", rvalue 2")
+    {
+        ByteMathData data = {1, 2, 3, 0, name, BM_MULTIPLY, 0, 0, 0,
+            ENDIAN_BIG, 0, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 202);
+    }
+    SECTION(
+        "1 byte read, offset 3, relative, cursor 3, operation \"-\", rvalue 3")
+    {
+        ByteMathData data = {1, 3, 3, 0, name, BM_MINUS, 1, 0, 0,
+            ENDIAN_BIG, 0, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption opt(data);
+        c.set_pos(3);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 46);
+    }
+    SECTION(
+        "cursor 3, 1 byte read, offset -3, relative, operation \"/\", rvalue 4")
+    {
+        ByteMathData data = {1, 4, -3, 0, name, BM_DIVIDE, 1, 0, 0,
+            ENDIAN_BIG, 0, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption opt(data);
+        c.set_pos(3);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 19);
+    }
+    SECTION(
+        "1 byte read, offset 6, string conv, base 10, operation \"+\", rvalue 4")
+    {
+        ByteMathData data = {1, 4, 6, 0, name, BM_PLUS, 0, 1, 10,
+            ENDIAN_BIG, 0, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 5);
+    }
+    SECTION(
+        "1 byte read, offset 6, string conv, base 10, operation \"<<\", rvalue 2")
+    {
+        ByteMathData data = {1, 2, 6, 0, name, BM_LEFT_SHIFT, 0, 1, 10,
+            ENDIAN_BIG, 0, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 4);
+    }
+    SECTION(
+        "3 byte read, offset 6, string conv, base 10, operation \">>\", rvalue 1")
+    {
+        ByteMathData data = {3, 1, 6, 0, name, BM_RIGHT_SHIFT, 0, 1, 10,
+            ENDIAN_BIG, 0, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 61);
+    }
+    SECTION("2 byte read, bitmask 1100110011100011, operation \"+\", rvalue 1")
+    {
+        ByteMathData data = {2, 1, 0, 52451, name, BM_PLUS, 0, 0, 0,
+            ENDIAN_BIG, 0, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 19556);
+    }
+    SECTION("2 byte read, bitmask 1100110011100000, operation \"-\", rvalue 5")
+    {
+        ByteMathData data = {2, 5, 0, 52448, name, BM_MINUS, 0, 0, 0,
+            ENDIAN_BIG, 0, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 606);
+    }
+    SECTION("4 bytes read, ENDIAN_LITTLE, operation \"-\", rvalue 5")
+    {
+        ByteMathData data = {4, 5, 0, 0, name, BM_MINUS, 0, 0, 0, 
+            ENDIAN_LITTLE, 0, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 1701998407);
+    }
+    SECTION("4 bytes read, ENDIAN_FUNC, packet.endianness = "
+        "DCERPC_BO_FLAG__LITTLE_ENDIAN, operation \"/\", rvalue 2")
+    {
+        DceEndianness* auto_endian = new DceEndianness();
+        auto_endian->hdr_byte_order = DCERPC_BO_FLAG__LITTLE_ENDIAN;
+        auto_endian->data_byte_order = DCERPC_BO_FLAG__LITTLE_ENDIAN;
+        p.endianness = auto_endian;
+        ByteMathData data = {4, 2, 0, 0, name, BM_DIVIDE, 0, 0, 0,
+            ENDIAN_FUNC, 0, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 850999206);
+    }
+    SECTION("2 bytes read, operation \">>\", result_var = 0, rvalue_var = 1")
+    {
+        SetVarValueByIndex(3, 1);
+        ByteMathData data = {2, 0, 0, 0, name, BM_RIGHT_SHIFT, 0,
+            0, 0, ENDIAN_BIG, 0, 1, IPS_OPTIONS_NO_VAR};
+        ByteMathOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 2445);
+    }
+    SECTION("1 byte read, operation \"<<\", offset_var = 0, result_var = 1")
+    {
+        SetVarValueByIndex(1, 0);
+        ByteMathData data = {1, 1, 0, 0, name, BM_LEFT_SHIFT,
+            0, 0, 0, ENDIAN_BIG, 1, IPS_OPTIONS_NO_VAR, 0};
+        ByteMathOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 1);
+        CHECK(res == 222);
+    }
+}
+
+TEST_CASE("ByteMathOption::eval invalid", "[byte_math_tests]")
+{
+    Packet p;
+    p.data = (const uint8_t*)"Lorem 9876";
+    p.dsize = 11;
+    Cursor c(&p);
+
+    for (unsigned i = 0; i < NUM_IPS_OPTIONS_VARS; ++i)
+    {
+        SetVarValueByIndex(0, i);
+    }
+    ClearIpsOptionsVars();
+
+    char* name = new char[5];
+    strcpy(name, "test");
+
+    SECTION("packet = nullptr")
+    {
+        ByteMathData data = {1, 1, 0, 0, name, BM_PLUS, 0, 0, 0,
+            ENDIAN_BIG, 0, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption opt(data);
+        CHECK(opt.eval(c, nullptr) == IpsOption::NO_MATCH);
+    }
+    SECTION("read more than 4 bytes")
+    {
+        ByteMathData data = {6, 1, 0, 0, name, BM_PLUS, 0, 0, 0, ENDIAN_BIG,
+            0, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::NO_MATCH);
+    }
+    SECTION("check bounds of packet, offset > packet size")
+    {
+        ByteMathData data = {1, 1, 20, 0, name, BM_PLUS, 0, 0, 0, ENDIAN_BIG,
+            0, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::NO_MATCH);
+    }
+    SECTION("negative offset, without relative flag")
+    {
+        ByteMathData data = {1, 1, -20, 0, name, BM_PLUS, 0, 0, 0, ENDIAN_BIG,
+            0, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::NO_MATCH);
+    }
+    SECTION("negative offset, out of bounds")
+    {
+        ByteMathData data = {1, 1, -20, 0, name, BM_PLUS, 1, 0, 0, ENDIAN_BIG,
+            0, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::NO_MATCH);
+    }
+    SECTION("check bounds of packet, read 2 bytes, empty packet")
+    {
+        p.data = (const uint8_t*)"";
+        p.dsize = 0;
+        Cursor c2(&p);
+        ByteMathData data = {2, 1, 0, 0, name, BM_PLUS, 0, 0, 0, ENDIAN_BIG,
+            0, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption opt(data);
+        CHECK(opt.eval(c2, &p) == IpsOption::NO_MATCH);
+    }
+    SECTION("ENDIAN_FUNC, without definition of endianness in packet")
+    {
+        ByteMathData data = {1, 1, 0, 0, name, BM_PLUS, 0, 0, 0, ENDIAN_FUNC,
+            0, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::NO_MATCH);
+    }
+    SECTION("conversion from string, decimal number, base = 8")
+    {
+        ByteMathData data = {3, 1, 6, 0, name, BM_PLUS, 0, 1, 8, ENDIAN_BIG,
+            0, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::NO_MATCH);
+    }
+    SECTION("rvalue_variable didn't exist")
+    {
+        ByteMathData data = {1, 1, 0, 0, name, BM_PLUS, 0,
+            0, 0, ENDIAN_BIG, 0, 1, IPS_OPTIONS_NO_VAR};
+        ByteMathOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 76);
+    }
+    SECTION("offset_variable didn't exist")
+    {
+        ByteMathData data = {1, 1, 1, 0, name, BM_PLUS, 0, 
+            0, 0, ENDIAN_BIG, 0, IPS_OPTIONS_NO_VAR, 1};
+        ByteMathOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 77);
+    }
+    SECTION("rvalue_variable_index > NUM_IPS_OPTIONS_VARS")
+    {
+        ByteMathData data = {1, 1, 0, 0, name, BM_PLUS, 0, 0, 0, ENDIAN_BIG,
+            0, NUM_IPS_OPTIONS_VARS + 1, IPS_OPTIONS_NO_VAR};
+        ByteMathOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 77);
+    }
+    SECTION("offset_variable_index > NUM_IPS_OPTIONS_VARS")
+    {
+        ByteMathData data = {1, 1, 1, 0, name, BM_PLUS, 0, 0, 0, ENDIAN_BIG,
+            0, IPS_OPTIONS_NO_VAR, NUM_IPS_OPTIONS_VARS + 1};
+        ByteMathOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::MATCH);
+        uint32_t res = 0;
+        GetVarValueByIndex(&res, 0);
+        CHECK(res == 112);
+    }
+    SECTION("get negative number with MINUS")
+    {
+        ByteMathData data = {1, 256, 0, 0, name, BM_MINUS, 0, 0, 0, ENDIAN_BIG,
+            0, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::NO_MATCH);
+    }
+    SECTION("out of bounds of unit_32t, PLUS")
+    {
+        ByteMathData data = {1, 4294967295, 0, 0, name, BM_PLUS, 0, 0, 0,
+            ENDIAN_BIG, 0, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::NO_MATCH);
+    }
+    SECTION("out of bounds of unit_32t, MULTIPLY")
+    {
+        ByteMathData data = {1, 2147483647, 0, 0, name, BM_MULTIPLY, 0, 0, 0,
+            ENDIAN_BIG, 0, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+        ByteMathOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::NO_MATCH);
+    }
+    SECTION("dividing on zero in rvalue_var")
+    {
+        SetVarValueByIndex(1, 0);
+        ByteMathData data = {1, 0, 0, 0, name, BM_DIVIDE, 0,
+            0, 0, ENDIAN_BIG, 0, 1, IPS_OPTIONS_NO_VAR};
+        ByteMathOption opt(data);
+        CHECK(opt.eval(c, &p) == IpsOption::NO_MATCH);
+    }
+}
+
+//-------------------------------------------------------------------------
+// module tests
+//-------------------------------------------------------------------------
+
+TEST_CASE("ByteMathModule::begin", "[byte_math_tests]")
+{
+    ByteMathModule obj;
+    SECTION("test of \"begin\" method")
+    {
+        CHECK(obj.begin(nullptr, 0, nullptr));
+        ByteMathData expected = {0, 0, 0, 0, 0, BM_PLUS, 0, 0, 0, 0, 0, 0, 0};
+
+        CHECK_THAT(obj.data, ByteMathDataEquals(expected));
+    }
+}
+
+TEST_CASE("ByteMathModule::end", "[byte_math_tests]")
+{
+    ByteMathModule obj;
+
+    obj.begin(nullptr, 0, nullptr);
+
+    Value v_name("test");
+    Parameter p_name = {"result", Parameter::PT_STRING, nullptr, nullptr,
+        "name of the variable to store the result"};
+    v_name.set(&p_name);
+    obj.set(nullptr, v_name, nullptr);
+
+    Value v_bytes(4.0);
+    Parameter p_bytes = {"bytes", Parameter::PT_INT, "1:10", nullptr,
+        "number of bytes to pick up from the buffer"};
+    v_bytes.set(&p_bytes);
+    obj.set(nullptr, v_bytes, nullptr);
+
+    Value v_operation(0.0);
+    Parameter p_operation = {"oper", Parameter::PT_ENUM, "+|-|*|/|<<|>>",
+        nullptr, "mathematical operation to perform"};
+    v_operation.set(&p_operation);
+    obj.set(nullptr, v_operation, nullptr);
+
+    char* name = new char[5];
+    strcpy(name, "test");
+
+    SECTION("without variables")
+    {
+        Value v_rvalue("7");
+        Parameter p_rvalue = {"rvalue", Parameter::PT_STRING, nullptr, nullptr,
+            "value to use mathematical operation against"};
+        v_rvalue.set(&p_rvalue);
+        obj.set(nullptr, v_rvalue, nullptr);
+
+        CHECK(obj.end(nullptr, 0, nullptr));
+
+        ByteMathData expected = {4, 7, 0, 0, name, BM_PLUS, 0, 0, 0, ENDIAN_BIG,
+            0, IPS_OPTIONS_NO_VAR, IPS_OPTIONS_NO_VAR};
+
+        CHECK_THAT(obj.data, ByteMathDataEquals(expected));
+    }
+    SECTION("with rvalue var")
+    {
+        ClearIpsOptionsVars();
+        int8_t var_idx = AddVarNameToList("rvalue_test_var");
+        SetVarValueByIndex(3, var_idx);
+
+        Value v_rvalue("rvalue_test_var");
+        Parameter p_rvalue = {"rvalue", Parameter::PT_STRING, nullptr, nullptr,
+            "value to use mathematical operation against"};
+        v_rvalue.set(&p_rvalue);
+        obj.set(nullptr, v_rvalue, nullptr);
+
+        CHECK(obj.end(nullptr, 0, nullptr));
+
+        ByteMathData expected = {4, 0, 0, 0, name, BM_PLUS, 0, 0, 0, 
+            ENDIAN_BIG, 0, var_idx, IPS_OPTIONS_NO_VAR};
+        CHECK_THAT(obj.data, ByteMathDataEquals(expected));
+    }
+    SECTION("with offset variable")
+    {
+        ClearIpsOptionsVars();
+        int8_t var_idx = AddVarNameToList("offset_test_var");
+        SetVarValueByIndex(3, var_idx);
+
+        Value v_offvalue("offset_test_var");
+        Parameter p_offvalue = { "offset", Parameter::PT_STRING, nullptr, nullptr,
+            "number of bytes into the buffer to start processing"};
+        v_offvalue.set(&p_offvalue);
+        obj.set(nullptr, v_offvalue, nullptr);
+
+        CHECK(obj.end(nullptr, 0, nullptr));
+
+        ByteMathData expected = {4, 0, 0, 0, name, BM_PLUS, 0, 0,
+            0, ENDIAN_BIG, 0, IPS_OPTIONS_NO_VAR, var_idx};
+        CHECK_THAT(obj.data, ByteMathDataEquals(expected));
+    }
+    SECTION("rvalue var doesn't exist")
+    {
+        ClearIpsOptionsVars();
+        Value v_rvalue("rvalue_test_var");
+        Parameter p_rvalue = {"rvalue", Parameter::PT_STRING, nullptr, nullptr,
+            "value to use mathematical operation against"};
+        v_rvalue.set(&p_rvalue);
+        obj.set(nullptr, v_rvalue, nullptr);
+
+        CHECK(!(obj.end(nullptr, 0, nullptr)));
+    }
+    SECTION("offset var doesn't exist")
+    {
+        ClearIpsOptionsVars();
+        Value v_offvalue("offset_test_var");
+        Parameter p_offvalue = { "offset", Parameter::PT_STRING, nullptr, nullptr,
+            "number of bytes into the buffer to start processing"};
+        v_offvalue.set(&p_offvalue);
+        obj.set(nullptr, v_offvalue, nullptr);
+
+        CHECK(!(obj.end(nullptr, 0, nullptr)));
+    }
+    delete name;
+}
+
+TEST_CASE("Test of byte_math_ctor", "[byte_math_tests]")
+{
+    ClearIpsOptionsVars();
+
+    std::string name = "test";
+    for (unsigned i = 0; i <= NUM_IPS_OPTIONS_VARS; ++i)
+    {
+        ByteMathModule obj;
+        obj.begin(nullptr, 0, nullptr);
+        Value v((name + std::to_string(i)).c_str());
+        Parameter p = {"result", Parameter::PT_STRING, nullptr, nullptr,
+            "name of the variable to store the result"};
+        v.set(&p);
+        obj.set(nullptr, v, nullptr);
+        if (i < NUM_IPS_OPTIONS_VARS)
+        {
+            IpsOption* res = byte_math_ctor(&obj, nullptr);
+            delete res;
+        }
+        else
+        {
+            IpsOption* res_null = byte_math_ctor(&obj, nullptr);
+            CHECK(res_null == nullptr);
+        }
+    }
+}
+
+TEST_CASE("ByteMathModule::set valid", "[byte_math_tests]")
+{
+    ByteMathModule obj;
+    obj.begin(nullptr, 0, nullptr);
+
+    SECTION("set bytes")
+    {
+        Value v(4.0);
+        Parameter p = {"bytes", Parameter::PT_INT, "1:10", nullptr,
+            "number of bytes to pick up from the buffer"};
+        v.set(&p);
+        ByteMathData expected = {4, 0, 0, 0, 0, BM_PLUS, 0, 0, 0, 0, 0, 0, 0};
+
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data, ByteMathDataEquals(expected));
+    }
+    SECTION("set offset")
+    {
+        Value v("3");
+        Parameter p = {"offset", Parameter::PT_STRING, nullptr, nullptr,
+            "number of bytes into the buffer to start processing"};
+        v.set(&p);
+        ByteMathData expected = {0, 0, 3, 0, 0, BM_PLUS, 0, 0, 0, 0, 0, 0, 0};
+
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data, ByteMathDataEquals(expected));
+    }
+    SECTION("set option \"+\"")
+    {
+        Value v(0.0);
+        Parameter p = {"oper", Parameter::PT_ENUM, "+|-|*|/|<<|>>", nullptr,
+            "mathematical operation to perform"};
+        v.set(&p);
+        ByteMathData expected = {0, 0, 0, 0, 0, BM_PLUS, 0, 0, 0, 0, 0, 0, 0};
+
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data, ByteMathDataEquals(expected));
+    }
+    SECTION("set option \"-\"")
+    {
+        Value v(1.0);
+        Parameter p = {"oper", Parameter::PT_ENUM, "+|-|*|/|<<|>>", nullptr,
+            "mathematical operation to perform"};
+        v.set(&p);
+        ByteMathData expected = {0, 0, 0, 0, 0, BM_MINUS, 0, 0, 0, 0, 0, 0, 0};
+
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data, ByteMathDataEquals(expected));
+    }
+    SECTION("set option \"*\"")
+    {
+        Value v(2.0);
+        Parameter p = {"oper", Parameter::PT_ENUM, "+|-|*|/|<<|>>", nullptr,
+            "mathematical operation to perform"};
+        v.set(&p);
+        ByteMathData expected = {0, 0, 0, 0, 0, BM_MULTIPLY, 0, 0, 0, 0, 0, 0, 0};
+
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data, ByteMathDataEquals(expected));
+    }
+    SECTION("set option \"/\"")
+    {
+        Value v(3.0);
+        Parameter p = {"oper", Parameter::PT_ENUM, "+|-|*|/|<<|>>", nullptr,
+            "mathematical operation to perform"};
+        v.set(&p);
+        ByteMathData expected = {0, 0, 0, 0, 0, BM_DIVIDE, 0, 0, 0, 0, 0, 0, 0};
+
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data, ByteMathDataEquals(expected));
+    }
+    SECTION("set option \"<<\"")
+    {
+        Value v(4.0);
+        Parameter p = {"oper", Parameter::PT_ENUM, "+|-|*|/|<<|>>", nullptr,
+            "mathematical operation to perform"};
+        v.set(&p);
+        ByteMathData expected = {0, 0, 0, 0, 0, BM_LEFT_SHIFT, 0, 0, 0, 0, 0, 0, 0};
+
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data, ByteMathDataEquals(expected));
+    }
+    SECTION("set option \">>\"")
+    {
+        Value v(5.0);
+        Parameter p = {"oper", Parameter::PT_ENUM, "+|-|*|/|<<|>>", nullptr,
+            "mathematical operation to perform"};
+        v.set(&p);
+        ByteMathData expected = {0, 0, 0, 0, 0, BM_RIGHT_SHIFT, 0, 0, 0, 0, 0, 0, 0};
+
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data, ByteMathDataEquals(expected));
+    }
+    SECTION("set rvalue num")
+    {
+        Value v("21");
+        Parameter p = {"rvalue", Parameter::PT_STRING, nullptr, nullptr,
+            "value to use mathematical operation against"};
+        v.set(&p);
+        ByteMathData expected = {0, 21, 0, 0, 0, BM_PLUS, 0, 0, 0, 0, 0, 0, 0};
+
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data, ByteMathDataEquals(expected));
+    }
+    SECTION("set result")
+    {
+        Value v("res_name");
+        Parameter p = {"result", Parameter::PT_STRING, nullptr, nullptr,
+            "name of the variable to store the result"};
+        v.set(&p);
+
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data.result_name, Catch::Matchers::Equals("res_name"));
+    }
+    SECTION("set relative")
+    {
+        Value v(true);
+        Parameter p = {"relative", Parameter::PT_IMPLIED, nullptr, nullptr,
+            "offset from cursor instead of start of buffer"};
+        v.set(&p);
+        obj.set(nullptr, v, nullptr);
+        ByteMathData expected = {0, 0, 0, 0, 0, BM_PLUS, 1, 0, 0, 0, 0, 0, 0};
+
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data, ByteMathDataEquals(expected));
+    }
+    SECTION("set endianess \"big\"")
+    {
+        Value v(0.0);
+        Parameter p = {"endian", Parameter::PT_ENUM, "big|little", nullptr,
+            "specify big/little endian"};
+        v.set(&p);
+        obj.set(nullptr, v, nullptr);
+        ByteMathData expected = {0, 0, 0, 0, 0, BM_PLUS, 0,
+            0, 0, ENDIAN_BIG, 0, 0, 0};
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data, ByteMathDataEquals(expected));
+    }
+    SECTION("set endianess \"little\"")
+    {
+        Value v(1.0);
+        Parameter p = {"endian", Parameter::PT_ENUM, "big|little", nullptr,
+            "specify big/little endian"};
+        v.set(&p);
+        ByteMathData expected = {0, 0, 0, 0, 0, BM_PLUS, 0, 0, 0, ENDIAN_LITTLE,
+            0, 0, 0};
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data, ByteMathDataEquals(expected));
+    }
+    SECTION("set dce")
+    {
+        Value v(true);
+        Parameter p = {"dce", Parameter::PT_IMPLIED, nullptr, nullptr,
+            "dcerpc2 determines endianess"};
+        v.set(&p);
+        ByteMathData expected = {0, 0, 0, 0, 0, BM_PLUS, 0, 
+            0, 0, ENDIAN_FUNC, 0, 0, 0};
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data, ByteMathDataEquals(expected));
+    }
+    SECTION("set string, hex base")
+    {
+        Value v(0.0);
+        Parameter p = {"string", Parameter::PT_ENUM, "hex|dec|oct", nullptr,
+            "convert extracted string to dec/hex/oct"};
+        v.set(&p);
+        ByteMathData expected = {0, 0, 0, 0, 0, BM_PLUS, 0, 1, 16, 0, 0, 0, 0};
+
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data, ByteMathDataEquals(expected));
+    }
+    SECTION("set string, dec base")
+    {
+        Value v(1.0);
+        Parameter p = {"string", Parameter::PT_ENUM, "hex|dec|oct", nullptr,
+            "convert extracted string to dec/hex/oct"};
+        v.set(&p);
+        ByteMathData expected = {0, 0, 0, 0, 0, BM_PLUS, 0, 1, 10, 0, 0, 0, 0};
+
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data, ByteMathDataEquals(expected));
+    }
+    SECTION("set string, octa base")
+    {
+        Value v(2.0);
+        Parameter p = {"string", Parameter::PT_ENUM, "hex|dec|oct", nullptr,
+            "convert extracted string to dec/hex/oct"};
+        v.set(&p);
+        ByteMathData expected = {0, 0, 0, 0, 0, BM_PLUS, 0, 1, 8, 0, 0, 0, 0};
+
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data, ByteMathDataEquals(expected));
+    }
+    SECTION("set bitmask")
+    {
+        Value v(1023.0);
+        Parameter p = {"bitmask", Parameter::PT_INT, "0x1:0xFFFFFFFF", nullptr,
+            "applies as bitwise AND to the extracted value before storage in 'name'"};
+        v.set(&p);
+        ByteMathData expected = {0, 0, 0, 1023, 0, BM_PLUS, 0, 0, 0, 0, 0, 0, 0};
+
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data, ByteMathDataEquals(expected));
+    }
+    SECTION("rvalue as variable")
+    {
+        Value v("r_test_var");
+        Parameter p = {"rvalue", Parameter::PT_STRING, nullptr, nullptr,
+            "value to use mathematical operation against"};
+        v.set(&p);
+
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK(strcmp(obj.rvalue_var.c_str(), "r_test_var") == 0);
+    }
+    SECTION("offset as variable")
+    {
+        Value v("off_test_var");
+        Parameter p = {"offset", Parameter::PT_STRING, nullptr, nullptr,
+            "number of bytes into the buffer to start processing"};
+        v.set(&p);
+
+        CHECK(obj.set(nullptr, v, nullptr));
+        CHECK(strcmp(obj.off_var.c_str(), "off_test_var") == 0);
+    }
+}
+
+TEST_CASE("ByteMathModule::set invalid", "[byte_math_tests]")
+{
+    ByteMathModule obj;
+    obj.begin(nullptr, 0, nullptr);
+
+    SECTION("invalid parameter")
+    {
+        Value v(1023.0);
+        Parameter p = {"error", Parameter::PT_INT, "nan", nullptr,
+            "not an option"};
+        v.set(&p);
+        ByteMathData expected = {0, 0, 0, 0, 0, BM_PLUS, 0, 0, 0, 0, 0, 0, 0};
+
+        CHECK(!obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data, ByteMathDataEquals(expected));
+    }
+    SECTION("rvalue = 0")
+    {
+        Value v("0");
+        Parameter p = {"rvalue", Parameter::PT_STRING, nullptr, nullptr,
+            "value to use mathematical operation against"};
+        v.set(&p);
+        ByteMathData expected = {0, 0, 0, 0, 0, BM_PLUS, 0, 0, 0, 0, 0, 0, 0};
+
+        CHECK(!obj.set(nullptr, v, nullptr));
+        CHECK_THAT(obj.data, ByteMathDataEquals(expected));
+    }
+}
+//-------------------------------------------------------------------------
+// api tests
+//-------------------------------------------------------------------------
+
+TEST_CASE("ByteMathVerify valid", "[byte_math_tests]")
+{
+    ByteMathData obj;
+    char* name = new char[5];
+    strcpy(name, "test");
+
+    SECTION("Minimum values, no string convertion")
+    {
+        obj = {1, 0, -65535, 0, name, BM_PLUS, 1, 0, 0, 0, 0, 0, 0};
+        CHECK(ByteMathVerify(&obj));
+    }
+    SECTION("Maximum values, no string convertion")
+    {
+        obj = {MAX_BYTES_TO_GRAB, 2147483647, 65535, 0xFFFFFFFF, name, BM_PLUS, 1, 0,
+            0, ENDIAN_FUNC, NUM_IPS_OPTIONS_VARS, NUM_IPS_OPTIONS_VARS, NUM_IPS_OPTIONS_VARS};
+        CHECK(ByteMathVerify(&obj));
+    }
+    SECTION("Minimum values, with string convertion")
+    {
+        obj = {1, 0, -65535, 0, name, BM_PLUS, 1, 1, 8, 0, 0, 0, 0};
+        CHECK(ByteMathVerify(&obj));
+    }
+    SECTION("Maximum values, with string convertion")
+    {
+        obj = {PARSELEN, 2147483647, 65535, 0xFFFFFFFF, name, BM_PLUS, 1, 1, 16, 
+            ENDIAN_FUNC, NUM_IPS_OPTIONS_VARS, NUM_IPS_OPTIONS_VARS, NUM_IPS_OPTIONS_VARS};
+        CHECK(ByteMathVerify(&obj));
+    }
+    delete name;
+}
+
+TEST_CASE("ByteMathVerify invalid", "[byte_math_tests]")
+{
+    char* name = new char[5];
+    strcpy(name, "test");
+    ByteMathData obj = {1, 9, 25, 1023, name, BM_PLUS, 1, 0, 0, 0, 0, 0, 0};
+
+    SECTION("name existence check")
+    {
+        obj.result_name = nullptr;
+
+        CHECK((!ByteMathVerify(&obj)));
+    }
+    SECTION("name not numeric check")
+    {
+        delete name;
+        name = new char[5];
+        strcpy(name, "9est");
+
+        CHECK((!ByteMathVerify(&obj)));
+    }
+    SECTION("shift > 32 checks")
+    {
+        obj.rvalue = 33;
+
+        obj.oper = BM_LEFT_SHIFT;
+        CHECK((!ByteMathVerify(&obj)));
+
+        obj.oper = BM_RIGHT_SHIFT;
+        CHECK((!ByteMathVerify(&obj)));
+    }
+    SECTION("shift && bytes_to_extract > 4  checks")
+    {
+        obj.bytes_to_extract = MAX_BYTES_TO_GRAB + 1;
+
+        obj.oper = BM_LEFT_SHIFT;
+        CHECK((!ByteMathVerify(&obj)));
+
+        obj.oper = BM_RIGHT_SHIFT;
+        CHECK((!ByteMathVerify(&obj)));
+    }
+    SECTION("no string conversion && bytes_to_extract > 4  checks")
+    {
+        obj.bytes_to_extract = MAX_BYTES_TO_GRAB + 1;
+        CHECK((!ByteMathVerify(&obj)));
+    }
+    SECTION("bitmask checks")
+    {
+        obj.bytes_to_extract = 2;
+        obj.bitmask_val = 1048575;
+        CHECK((!ByteMathVerify(&obj)));
+    }
+    delete name;
+}
+
+#endif


### PR DESCRIPTION
- Adding unit tests to  ips_options/ips_byte_extract\jump\math\test.cc files and framework/ips_options.cc;
- Refactoring of ips_options/ips_byte_extract\jump\math\test.cc  files;
- Moving the common logic of the bytes extraction from ips_options/ips_byte_extract\jump\math\test.cc  into extract.cc;
- Adding unit tests for byte extraction logic in ips_options/extract.cc;

At snort3_demo tests, behaves similarly to master branch, and performance test results also same as master.