### PR TITLE
Fix typos in docs and dev_notes

### DIFF
--- a/doc/user/connectors.txt
+++ b/doc/user/connectors.txt
@@ -38,7 +38,7 @@ TcpConnector adds a few session setup configuration elements:
 
 * address = '<addr>' - used for 'call' setup to specify the partner
 
-* base_port = port - used to contruct the actual port number for 'call' and
+* base_port = port - used to construct the actual port number for 'call' and
         'answer' modes.  Actual port used is (base_port + instance_id).
 
 An example segment of TcpConnector configuration:

--- a/src/ports/dev_notes.txt
+++ b/src/ports/dev_notes.txt
@@ -180,7 +180,7 @@ All any-any port rules are managed separately, and added in to the final
 rules lists of each port group after this analysis. Rules defined with
 ranges are no longer considered any-any rules for the purpose of organizing
 port-rule groupings.  This should help prevent some cross fertilization of
-rule groups with rules that are unneccessary, this causes rule group sizes
+rule groups with rules that are unnecessary, this causes rule group sizes
 to bloat and performance to slow.
 
 *Hierarchy*

--- a/src/profiler/dev_notes.txt
+++ b/src/profiler/dev_notes.txt
@@ -4,7 +4,7 @@ statistics, as well as the display of those statistics at shutdown.
 
 This module provides a data structure (called ProfileStats) which stores
 information about memory usage, timing and entry counts.
-Analagous data structures exist for accumulating rule profiling and can be found
+Analogous data structures exist for accumulating rule profiling and can be found
 in the detection/ subdirectory.
 
 To facilitate accumulation of these statistics, this module provides a class

--- a/src/service_inspectors/http_inspect/dev_notes.txt
+++ b/src/service_inspectors/http_inspect/dev_notes.txt
@@ -233,7 +233,7 @@ A config option to set the limit manually:
  * http_inspect.js_norm_identifier_depth.
 
 Identifiers from the ignore list will be placed as is, without substitution. Starting with 
-the listed identifier, any chain of dot acessors, brackets and function calls will be kept
+the listed identifier, any chain of dot accessors, brackets and function calls will be kept
 intact.
 For example:
  * console.log("bar")


### PR DESCRIPTION
doc/user/connectors.txt:41:    contruct -> construct
src/ports/dev_notes.txt:183:   unneccessary -> unnecessary
src/profiler/dev_notes.txt:7:  Analagous -> Analogous
src/service_inspectors/http_inspect/dev_notes.txt:236: acessors -> accessors
