### PR TITLE
Update Util.cc: flatbuffer_version_string

### DIFF
--- a/src/utils/util.cc
+++ b/src/utils/util.cc
@@ -116,7 +116,7 @@ int DisplayBanner()
     LogMessage("           Using PCRE version %s\n", pcre_version());
     LogMessage("           Using ZLIB version %s\n", zlib_version);
 #ifdef HAVE_FLATBUFFERS
-    LogMessage("           Using %s\n", flatbuffers::flatbuffer_version_string);
+    LogMessage("           Using %s\n", flatbuffers::flatbuffers_version_string);
 #endif
 #ifdef HAVE_HYPERSCAN
     LogMessage("           Using Hyperscan version %s\n", hs_version());


### PR DESCRIPTION
flatbuffer_version_string -> flatbuffers_version_string

**Fixed error:**
error: 'flatbuffer_version_string' is not a member of 'flatbuffers'; did you mean 'flatbuffers_version_string'?