### PR TITLE
Specify Parallelization in Make

### DIFF
--- a/doc/user/tutorial.txt
+++ b/doc/user/tutorial.txt
@@ -89,7 +89,7 @@ a. To build with cmake and make, run configure_cmake.sh.  It will
 
     ./configure_cmake.sh --prefix=$my_path
     cd build
-    make -j
+    make -j $(numproc)
     make install
     ln -s $my_path/conf $my_path/etc
 


### PR DESCRIPTION
Running make -j without a value causes make to attempt to build far too many targets at once.  This also brings the docs closer to matching the README.md in the root of the project.