### PR TITLE
[fix]: There is a risk of memory leakage

### DIFF
--- a/src/stream/tcp/tcp_reassembler.cc
+++ b/src/stream/tcp/tcp_reassembler.cc
@@ -266,7 +266,10 @@ void TcpReassembler::dup_reassembly_segment(
 
 bool TcpReassembler::add_alert(TcpReassemblerState& trs, uint32_t gid, uint32_t sid)
 {
-    trs.alerts.emplace_back(gid, sid, 0, 0, 0);
+    if (!this->check_alerted(trs,gid, sid))
+    {
+        trs.alerts.emplace_back(gid, sid, 0, 0, 0);
+    }
     return true;
 }
 


### PR DESCRIPTION
There is a risk of memory leakage when the same session generates a lot of alarms
![snort-outof-memery](https://user-images.githubusercontent.com/38171981/194839173-9d2f4c92-107a-4fc4-a02a-60ec3f209bb2.jpg)
