### PR TITLE
FindFlexLexer.cmake: fix sed call

### DIFF
--- a/cmake/FindFlexLexer.cmake
+++ b/cmake/FindFlexLexer.cmake
@@ -16,11 +16,11 @@ macro(FLEX NAME LEXER_IN LEXER_OUT)
         COMPILE_FLAGS ${FLEX_FLAGS}
     )
 
-    # we use '+' as a separator for 'sed' to avoid conflicts with '/' in paths from LEXER_OUT
+    # we use '|' as a separator for 'sed' to avoid conflicts with '/' in paths from LEXER_OUT
     add_custom_command(
         OUTPUT ${LEXER_OUT}
         COMMAND sed -e
-            "s+void yyFlexLexer::LexerError+yynoreturn void yyFlexLexer::LexerError+;s+${LEXER_OUT}.tmp+${LEXER_OUT}+"
+            "s|void yyFlexLexer::LexerError|yynoreturn void yyFlexLexer::LexerError|;s|${LEXER_OUT}.tmp|${LEXER_OUT}|"
             ${FLEX_${NAME}_OUTPUTS} > ${LEXER_OUT}
         DEPENDS ${FLEX_${NAME}_OUTPUTS}
         VERBATIM


### PR DESCRIPTION
Use '|' rather than '+' for sed separator.  On OpenWrt, for example, some target names contain a '+' in their directory name and cannot build without this modification.

Signed-off-by: graysky <therealgraysky@proton.me>