### PR TITLE
Move parameter which might be empty to last position

### DIFF
--- a/doc/reference/CMakeLists.txt
+++ b/doc/reference/CMakeLists.txt
@@ -86,7 +86,7 @@ list ( APPEND BUILT_SOURCES version.txt )
 
 add_custom_command (
     OUTPUT builtin.txt
-    COMMAND ${CMAKE_CURRENT_LIST_DIR}/scripts/generate_builtin.sh $<TARGET_FILE:snort> $ENV{SNORT_PLUGIN_PATH} ${CMAKE_CURRENT_LIST_DIR}/builtin_stubs.txt builtin.txt
+    COMMAND ${CMAKE_CURRENT_LIST_DIR}/scripts/generate_builtin.sh $<TARGET_FILE:snort> ${CMAKE_CURRENT_LIST_DIR}/builtin_stubs.txt builtin.txt $ENV{SNORT_PLUGIN_PATH}
     DEPENDS snort
     COMMENT "Documents: building builtin.txt"
 )

--- a/doc/reference/scripts/generate_builtin.sh
+++ b/doc/reference/scripts/generate_builtin.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 SNORT_BINARY="$1"
-PLUGIN_PATH="$2"
-INPUT_FILE="$3"
-OUTPUT_FILE="$4"
+INPUT_FILE="$2"
+OUTPUT_FILE="$3"
+PLUGIN_PATH="$4"
 
 PLUGIN_ARGS=
 


### PR DESCRIPTION
In Debian builds $ENV{SNORT_PLUGIN_PATH} is empty, and the logic in generate_built.sh to handle PLUGIN_PATH being empty is broken. An empty parameter in shell won't cause PLUGIN_PATH to be empty, it takes the value that is expected for INPUT_FILE and INPUT_FILE takes the value expected for OUTPUT_FILE and OUTPUT_FILE ends up empty.

This patch moves the parameter which might be empty to the end of the command.

Cheers,
Andrew