### PR TITLE
packet_capture: Fix compilation with GCC 13

### DIFF
--- a/src/network_inspectors/packet_capture/packet_capture.h
+++ b/src/network_inspectors/packet_capture/packet_capture.h
@@ -21,6 +21,7 @@
 #define PACKET_CAPTURE_H
 
 #include <string>
+#include <cstdint>
 
 void packet_capture_enable(const std::string&, const int16_t g = -1, const std::string& t = "");
 void packet_capture_disable();


### PR DESCRIPTION
Fix the following compile problem with GCC 13:
````
src/network_inspectors/packet_capture/packet_capture.h:25:54: error: 'int16_t' does not name a type
   25 | void packet_capture_enable(const std::string&, const int16_t g = -1, const std::string& t = "");
````