### PR TITLE
Add a missing header in packet_capture.h

### DIFF
--- a/src/network_inspectors/packet_capture/packet_capture.h
+++ b/src/network_inspectors/packet_capture/packet_capture.h
@@ -21,6 +21,7 @@
 #define PACKET_CAPTURE_H
 
 #include <string>
+#include <cstdint>
 
 void packet_capture_enable(const std::string&, const int16_t g = -1, const std::string& t = "");
 void packet_capture_disable();


### PR DESCRIPTION
I got an error when compiling snort on a QEMU x86_64 VM saying:

> src/network_inspectors/packet_capture/packet_capture.h:25:59: error: 'int16_t' does not name a type

This fixes it. My days with C++ are long gone so I'm not sure if this is the best place to fix it.