### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/src/actions/actions_module.h
+++ b/src/actions/actions_module.h
@@ -25,6 +25,9 @@
 
 #include <map>
 #include <vector>
+#if defined(__FreeBSD__) || defined(__DragonFly__)
+#include <array>
+#endif
 
 #include "framework/module.h"
 

--- a/src/utils/util.cc
+++ b/src/utils/util.cc
@@ -83,14 +83,7 @@ bool get_file_size(const std::string& path, size_t& size)
 }
 
 #if defined(NOCOREFILE)
-void SetNoCores()
-{
-    struct rlimit rlim;
-
-    getrlimit(RLIMIT_CORE, &rlim);
-    rlim.rlim_max = 0;
-    setrlimit(RLIMIT_CORE, &rlim);
-}
+void SetNoCores();
 #endif
 
 namespace snort

--- a/src/utils/util.h
+++ b/src/utils/util.h
@@ -27,6 +27,9 @@
 #if defined(__linux__)
 #include <sys/syscall.h>
 #endif
+#if defined(__FreeBSD__) || defined(__DragonFly__)
+#include <sys/types.h>
+#endif
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <unistd.h>


### PR DESCRIPTION
- Fix `error: implicit instantiation of undefined template 'std::array<PegInfo, 255>'`
- Fix `error: variable has incomplete type 'struct rlimit'`
- Fix
```
ld: error: duplicate symbol: SetNoCores()
>>> defined at process.cc
>>>            src/main/CMakeFiles/main.dir/process.cc.o:(SetNoCores())
>>> defined at util.cc
>>>            src/utils/CMakeFiles/utils.dir/util.cc.o:(.text+0x150)
```