### PR TITLE
cmake: fix pkg-config path for libdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ the latest:
 * PCRE2 from http://www.pcre.org for regular expression pattern matching
 * pkgconfig from https://www.freedesktop.org/wiki/Software/pkg-config/ to locate build dependencies
 * zlib from http://www.zlib.net for decompression
+* LZMA/xz from https://tukaani.org/xz/ for compression
 
 Additional packages provide optional features.  Check the manual for more.
 

--- a/cmake/create_pkg_config.cmake
+++ b/cmake/create_pkg_config.cmake
@@ -5,7 +5,7 @@
 set(prefix "${CMAKE_INSTALL_PREFIX}")
 set(exec_prefix "\${prefix}")
 set(bindir "\${exec_prefix}/bin")
-set(libdir "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
+set(libdir "\${CMAKE_INSTALL_FULL_LIBDIR}")
 set(includedir "\${prefix}/include")
 set(datarootdir "\${prefix}/share")
 set(datadir "\${datarootdir}")


### PR DESCRIPTION
On systems that prefer absolute paths there is a mixing and matching of
the relative and absolute paths that can result in the below creation of
libdir having the prefix and the full path appended to it.


```
prefix=/nix/store/3npvhj5wfwhc0q42qwiinj64bzfb1vvz-snort-3.6.3.0
exec_prefix=${prefix}
bindir=${exec_prefix}/bin
**libdir=${prefix}//nix/store/3npvhj5wfwhc0q42qwiinj64bzfb1vvz-snort-3.6.3.0/lib**
includedir=${prefix}/include
datarootdir=${prefix}/share
datadir=${datarootdir}
mandir=${datarootdir}/man
infodir=${datarootdir}/info
```

In order to preserve backwards compatibility we will use the cmake
fullpath option ${CMAKE_INSTALL_FULL_LIBDIR} in place of
${prefix}/${CMAKE_INSTALL_LIBDIR} which will support both contexts.

This is discussed in the following issue tracker for NixOS https://github.com/NixOS/nixpkgs/issues/144170


