### PR TITLE
Fix build with gcc-15

### DIFF
--- a/tools/snort2lua/config_states/config_ignore_ports.cc
+++ b/tools/snort2lua/config_states/config_ignore_ports.cc
@@ -21,6 +21,7 @@
 #include <vector>
 #include <string>
 #include <stdexcept>
+#include <cstdint>
 
 #include "conversion_state.h"
 #include "helpers/converter.h"

--- a/tools/snort2lua/preprocessor_states/pps_dcerpc_server.cc
+++ b/tools/snort2lua/preprocessor_states/pps_dcerpc_server.cc
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <cstdint>
 
 namespace preprocessors
 {

--- a/tools/snort2lua/preprocessor_states/pps_frag3_engine.cc
+++ b/tools/snort2lua/preprocessor_states/pps_frag3_engine.cc
@@ -19,6 +19,7 @@
 
 #include <sstream>
 #include <vector>
+#include <cstdint>
 
 #include "conversion_state.h"
 #include "helpers/converter.h"

--- a/tools/snort2lua/preprocessor_states/pps_stream5_tcp.cc
+++ b/tools/snort2lua/preprocessor_states/pps_stream5_tcp.cc
@@ -20,6 +20,7 @@
 #include <sstream>
 #include <vector>
 #include <string>
+#include <cstdint>
 
 #include "conversion_state.h"
 #include "helpers/s2l_util.h"

--- a/tools/snort2lua/rule_states/rule_gid_sid.cc
+++ b/tools/snort2lua/rule_states/rule_gid_sid.cc
@@ -27,6 +27,7 @@
 
 #include <sstream>
 #include <unordered_map>
+#include <cstdint>
 
 #include "conversion_state.h"
 #include "helpers/converter.h"


### PR DESCRIPTION

Hello,
I got some errors when building with gcc-15

```
/home/worker/nano-ai/build-nano-ai/BUILD/work/qcs8550_aihub-webos-linux/snort3/3.6.1.0/git/tools/snort2lua/rule_states/rule_gid_sid.cc:42:11: error: 'uint8_t' does not name a type                                           
   42 | constexpr uint8_t MAX_GIDS = (sizeof(removed_gids) / sizeof(removed_gids[0]));                                                                                                                                        
      |           ^~~~~~~                                                                                                                                                                                                     
/home/worker/nano-ai/build-nano-ai/BUILD/work/qcs8550_aihub-webos-linux/snort3/3.6.1.0/git/tools/snort2lua/rule_states/rule_gid_sid.cc:35:1: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by add
ing '#include <cstdint>'                                                                                                                                                                                                      
   34 | #include "rule_api.h"                                                                                                                                                                                                 
  +++ |+#include <cstdint>                                                                                                                                                                                                    
   35 |                                                                                                                                                                                                                       
/home/worker/nano-ai/build-nano-ai/BUILD/work/qcs8550_aihub-webos-linux/snort3/3.6.1.0/git/tools/snort2lua/rule_states/rule_gid_sid.cc:57:27: error: 'MAX_GIDS' was not declared in this scope                                
   57 |     static bool gids_seen[MAX_GIDS];                                                                                                                                                                                  
      |                           ^~~~~~~~                                                                                                                                                                                    
/home/worker/nano-ai/build-nano-ai/BUILD/work/qcs8550_aihub-webos-linux/snort3/3.6.1.0/git/tools/snort2lua/rule_states/rule_gid_sid.cc:73:21: error: 'MAX_GIDS' was not declared in this scope                                
   73 | bool Gid::gids_seen[MAX_GIDS];                                                                                                                                                                                        
      |                     ^~~~~~~~
/home/worker/nano-ai/build-nano-ai/BUILD/work/qcs8550_aihub-webos-linux/snort3/3.6.1.0/git/tools/snort2lua/rule_states/rule_gid_sid.cc: In member function 'virtual bool rules::{anonymous}::Gid::convert(std::istringstream&)
':
/home/worker/nano-ai/build-nano-ai/BUILD/work/qcs8550_aihub-webos-linux/snort3/3.6.1.0/git/tools/snort2lua/rule_states/rule_gid_sid.cc:81:26: error: 'MAX_GIDS' was not declared in this scope
   81 |     for ( int i = 0; i < MAX_GIDS; i++ )
      |                          ^~~~~~~~
/home/worker/nano-ai/build-nano-ai/BUILD/work/qcs8550_aihub-webos-linux/snort3/3.6.1.0/git/tools/snort2lua/rule_states/rule_gid_sid.cc:85:19: error: 'gids_seen' was not declared in this scope
...
/home/worker/nano-ai/build-nano-ai/BUILD/work/qcs8550_aihub-webos-linux/snort3/3.7.1.0/git/tools/snort2lua/preprocessor_states/pps_frag3_engine.cc: In member function 'std::string preprocessors::{anonymous}::Frag3Engine::c
hoose_table_name(std::istringstream&)':                                                                                                                                                                                       
/home/worker/nano-ai/build-nano-ai/BUILD/work/qcs8550_aihub-webos-linux/snort3/3.7.1.0/git/tools/snort2lua/preprocessor_states/pps_frag3_engine.cc:45:12: error: 'uint32_t' does not name a type                              
   45 |     static uint32_t binding_id = 0;                                                                                                                                                                                   
      |            ^~~~~~~~                                                                                                                                                                                                   
/home/worker/nano-ai/build-nano-ai/BUILD/work/qcs8550_aihub-webos-linux/snort3/3.7.1.0/git/tools/snort2lua/preprocessor_states/pps_frag3_engine.cc:26:1: note: 'uint32_t' is defined in header '<cstdint>'; this is probably f
ixable by adding '#include <cstdint>'                                                                                                                                                                                         
   25 | #include "helpers/s2l_util.h"                                                                                                                                                                                         
  +++ |+#include <cstdint>                                                                                                                                                                                                    
   26 | #include "helpers/util_binder.h"                                                                                                                                                                                      
/home/worker/nano-ai/build-nano-ai/BUILD/work/qcs8550_aihub-webos-linux/snort3/3.7.1.0/git/tools/snort2lua/preprocessor_states/pps_frag3_engine.cc:55:50: error: 'binding_id' was not declared in this scope                  
   55 |             return "stream_ip_" + std::to_string(binding_id++);       
...
```
I create this PR for fix this issue above.
Thanks,
