### PR TITLE
build: support cmake 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.4.3)
+cmake_minimum_required (VERSION 3.5)
 project (snort CXX C)
 
 set (VERSION_MAJOR 3)


### PR DESCRIPTION
update cmake min version to support cmake 4.0

relates to https://github.com/Homebrew/homebrew-core/pull/217465