### PR TITLE
fix: prevent empty variable error when checking tcmalloc and jemalloc…

### DIFF
--- a/configure_cmake.sh
+++ b/configure_cmake.sh
@@ -520,7 +520,10 @@ while [ $# -ne 0 ]; do
     shift
 done
 
-if [ "$tcm" -eq 1 -a "$jem" -eq 1 ] ; then
+tcm=${tcm:-0}
+jem=${jem:-0}
+
+if [ "$tcm" -eq 1 ] && [ "$jem" -eq 1 ]; then
     echo "--enable-jemalloc and --enable-tcmalloc are mutually exclusive; enable at most one"
     exit 2
 fi


### PR DESCRIPTION
Fixes a shell error caused by uninitialized `tcm` and `jem` variables during integer comparison. Sets default values to `0` to avoid `integer expression expected` errors when the flags are unset.