### PR TITLE
Fix build on c23

### DIFF
--- a/src/loggers/alert_fast.cc
+++ b/src/loggers/alert_fast.cc
@@ -53,7 +53,7 @@ using namespace std;
 #define FAST_BUF (4*K_BYTES)
 
 static THREAD_LOCAL TextLog* fast_log = nullptr;
-static once_flag init_flag;
+static std::once_flag init_flag;
 
 #define S_NAME "alert_fast"
 #define F_NAME S_NAME ".txt"
@@ -319,7 +319,7 @@ void FastLogger::set_buffer_ids(Inspector* gadget)
 const BufferIds& FastLogger::get_buffer_ids(Inspector* gadget, Packet* p)
 {
     // lazy init required because loggers don't have a configure (yet)
-    call_once(init_flag, set_buffer_ids, gadget);
+    std::call_once(init_flag, set_buffer_ids, gadget);
 
     InspectionBuffer buf;
     const std::vector<unsigned>& idv =


### PR DESCRIPTION
C23/glibc is now including once_init in stdlib.h

https://patchwork.sourceware.org/project/glibc/patch/78061085-f04a-0c45-107b-5a8a15521083@redhat.com/#213088

This is a name collision with the new C once_flag/call_once that glibc exposes (via <stdlib.h>) and C++’s std::once_flag/std::call_once