### PR TITLE
Fix PAWS timestamp validation to comply with RFC7323

### DIFF
--- a/src/stream/tcp/tcp_normalizer.cc
+++ b/src/stream/tcp/tcp_normalizer.cc
@@ -499,10 +499,12 @@ int TcpNormalizer::validate_paws_timestamp(
         && ( ( uint32_t )tsd.get_packet_timestamp() > tns.peer_tracker->get_ts_last_packet() +
         PAWS_24DAYS ) )
     {
-        /* this packet is from way too far into the future */
-        tns.session->tel.set_tcp_event(EVENT_BAD_TIMESTAMP);
-        packet_dropper(tns, tsd, NORM_TCP_OPT);
-        return ACTION_BAD_PKT;
+        /* Per RFC7323 Section 5.5: After 24 days of inactivity, TS.Recent should be
+         * invalidated to allow the connection to continue. Accept the packet and reset
+         * the timestamp rather than dropping it. */
+        tns.peer_tracker->set_ts_last(0);
+        tns.peer_tracker->set_ts_last_packet(0);
+        return ACTION_NOTHING;
     }
     else
         return ACTION_NOTHING;


### PR DESCRIPTION
I noticed issue #407 about PAWS timestamp handling not following RFC7323 correctly. After reading the RFC, it's clear that when a connection has been idle for more than 24 days, we should invalidate TS.Recent and allow the packet through, not drop it.

The current code was dropping packets that came in after long idle periods, which breaks legitimate long-lived TCP connections. This changes the behavior to match what the RFC specifies - we reset the timestamp tracking and accept the packet.

This should fix the unnecessary packet drops mentioned in #407 while still maintaining proper PAWS protection for active connections.

Fixes #407