### PR TITLE
doc: update recommended zlib version to 1.2.12 for CVE-2018-25032

### DIFF
--- a/doc/user/tutorial.txt
+++ b/doc/user/tutorial.txt
@@ -31,7 +31,8 @@ Required:
 * pkgconfig from https://www.freedesktop.org/wiki/Software/pkg-config/ to locate
   build dependencies
 
-* zlib from http://www.zlib.net for decompression (>= 1.2.8 recommended)
+* zlib from http://www.zlib.net for decompression (>= 1.2.12 recommended due to
+  CVE-2018-25032)
 
 Optional:
 


### PR DESCRIPTION
Updates the recommended zlib version from 1.2.8 to 1.2.12 to address CVE-2018-25032.
This will fix the issue #238.