### PR TITLE
Fix issue #376: Prevent JSON object splitting during file rollover

### DIFF
--- a/src/log/text_log.cc
+++ b/src/log/text_log.cc
@@ -56,6 +56,7 @@ struct TextLog
     size_t size;
     size_t maxFile;
     time_t last;
+    bool defer_rollover;
 
 /* buffer attributes: */
     unsigned int pos;
@@ -137,6 +138,7 @@ TextLog* TextLog_Init(
     txt->size = TextLog_Size(txt->file);
     txt->last = time(nullptr);
     txt->maxFile = maxFile;
+    txt->defer_rollover = false;
 
     txt->maxBuf = maxBuf;
     TextLog_Reset(txt);
@@ -193,7 +195,7 @@ bool TextLog_Flush(TextLog* const txt)
     if ( !txt->pos )
         return false;
 
-    if ( txt->maxFile and txt->size + txt->pos > txt->maxFile )
+    if ( !txt->defer_rollover and txt->maxFile and txt->size + txt->pos > txt->maxFile )
         TextLog_Roll(txt);
 
     ok = fwrite(txt->buf, txt->pos, 1, txt->file);
@@ -318,5 +320,10 @@ bool TextLog_Quote(TextLog* const txt, const char* qs)
     TextLog_Putc(txt, '"');
 
     return true;
+}
+
+void TextLog_DeferRollover(TextLog* const txt, bool defer)
+{
+    txt->defer_rollover = defer;
 }
 } // namespace snort

--- a/src/log/text_log.h
+++ b/src/log/text_log.h
@@ -60,6 +60,7 @@ SO_PUBLIC bool TextLog_Print(TextLog* const, const char* format, ...) __attribut
 SO_PUBLIC bool TextLog_Flush(TextLog* const);
 SO_PUBLIC int TextLog_Avail(TextLog* const);
 SO_PUBLIC void TextLog_Reset(TextLog* const);
+SO_PUBLIC void TextLog_DeferRollover(TextLog* const, bool defer);
 } // namespace snort
 
 /*-------------------------------------------------------------------

--- a/src/loggers/alert_json.cc
+++ b/src/loggers/alert_json.cc
@@ -838,6 +838,8 @@ void JsonLogger::close()
 void JsonLogger::alert(Packet* p, const char* msg, const Event& event)
 {
     Args a = { p, msg, event, false };
+    
+    TextLog_DeferRollover(json_log, true);
     TextLog_Putc(json_log, '{');
 
     for ( JsonFunc f : fields )
@@ -847,6 +849,7 @@ void JsonLogger::alert(Packet* p, const char* msg, const Event& event)
     }
 
     TextLog_Print(json_log, " }\n");
+    TextLog_DeferRollover(json_log, false);
     TextLog_Flush(json_log);
 }
 


### PR DESCRIPTION
This PR fixes issue #376 where alert_json file rollover was splitting JSON objects across file boundaries, resulting in invalid JSON lines when large b64_data fields exceeded the size limit mid-write. The solution implements a defer_rollover mechanism that prevents file rotation during JSON serialization by wrapping object writes with defer flags, ensuring rollover only happens between complete JSON objects. This keeps all JSON lines valid and parseable across rotated files.