### PR TITLE
Add ICMP support to tunnel bypass mechanism

### DIFF
--- a/src/main/snort_config.h
+++ b/src/main/snort_config.h
@@ -122,7 +122,8 @@ enum TunnelFlags
     TUNNEL_GRE    = 0x40,
     TUNNEL_MPLS   = 0x80,
     TUNNEL_VXLAN  = 0x100,
-    TUNNEL_GENEVE = 0x200
+    TUNNEL_GENEVE = 0x200,
+    TUNNEL_ICMP   = 0x400
 };
 
 enum DumpConfigType

--- a/src/packet_io/sfdaq_instance.cc
+++ b/src/packet_io/sfdaq_instance.cc
@@ -252,6 +252,8 @@ void SFDAQInstance::get_tunnel_capabilities()
             daq_tunnel_mask |= TUNNEL_MPLS;
         if (caps & DAQ_CAPA_DECODE_GENEVE)
             daq_tunnel_mask |= TUNNEL_GENEVE;
+        if (caps & DAQ_CAPA_DECODE_ICMP)
+            daq_tunnel_mask |= TUNNEL_ICMP;
     }
 }
 


### PR DESCRIPTION
ICMP packets were being silently dropped in NFQ inline mode because they weren't included in Snort's tunnel bypass handling. This fix adds ICMP as a supported tunnel protocol alongside GTP, TEREDO, GRE, and others. Incoming ICMP packets should now be properly handled instead of being dropped in NFQ prerouting/postrouting configuration.