### PR TITLE
log: fix TextLog STDLOG detection for musl libc (issue #444)

### DIFF
--- a/src/log/text_log.cc
+++ b/src/log/text_log.cc
@@ -31,6 +31,7 @@
 
 #include "text_log.h"
 
+#include <fcntl.h>
 #include <sys/stat.h>
 #include <time.h>
 
@@ -72,11 +73,15 @@ static FILE* TextLog_Open(const char* name, bool is_critical=true)
     if ( name && !strcasecmp(name, "stdout") )
     {
 #ifdef USE_STDLOG
-        FILE* stdlog = fdopen(STDLOG_FILENO, "w");
-        return stdlog ? stdlog : stdout;
-#else
-        return stdout;
+        // Use fcntl to check if fd is actually open, fdopen on musl always succeeds
+        // even for invalid fds, unlike glibc which validates first.
+        if ( fcntl(STDLOG_FILENO, F_GETFD) != -1 )
+        {
+            FILE* stdlog = fdopen(STDLOG_FILENO, "w");
+            return stdlog ? stdlog : stdout;
+        }
 #endif
+        return stdout;
     }
 
     return OpenAlertFile(name, is_critical);


### PR DESCRIPTION
## Summary

Fixes #444 — on musl libc (e.g. Alpine Linux), `fdopen()` does not validate the input fd before wrapping it. Unlike glibc, which internally calls `fcntl(F_GETFL)` and returns `NULL` for an invalid fd, musl always returns a non-NULL `FILE*`. This caused `TextLog_Open()` to always treat STDLOG (fd 3) as open, even when it was not.

### Impact

When STDLOG is not actually open, the next file opened by Snort or a plugin receives fd 3. The text logger and that file then share the same fd, leading to silent data corruption or unexpected behavior.

## Fix

Replace the `fdopen`-based check with `fcntl(STDLOG_FILENO, F_GETFD) != -1`, which is the POSIX-standard, portable way to test whether a file descriptor is open. This works correctly on both glibc and musl.

## Testing

- Built successfully on glibc/Linux (`make -j$(nproc) snort`, zero errors)
- `snort -T` config validation passes with zero errors
- `snort -A fast -T` (directly exercises the `TextLog_Open("stdout")` path) passes with zero errors

## Credit

Original patch and analysis by @mike-at-trout-software.