### PR TITLE
fix: use stats.allocated for memory cap enforcement

### DIFF
--- a/src/memory/heap_interface.cc
+++ b/src/memory/heap_interface.cc
@@ -85,7 +85,7 @@ static void log_jem_stats(void *,const char *buf)
 
 void JemallocInterface::main_init()
 {
-    mallctlnametomib("stats.mapped", stats_mib, &mib_len);
+    mallctlnametomib("stats.allocated", stats_mib, &mib_len);
 }
 
 void JemallocInterface::thread_init()


### PR DESCRIPTION
## Summary

- **Fix memory cap metric**: Change jemalloc stat from `stats.mapped` to `stats.allocated` in `heap_interface.cc:88`. `stats.mapped` includes retained virtual pages that are never returned to the OS, causing monotonic memory growth and ineffective cap enforcement. `stats.allocated` tracks actual application memory usage, matching the documented behavior in `dev_notes.txt` line 9.

## Problem

Snort3 exhibits continuous memory growth even when no rules are loaded. The root cause is that `stats.mapped` monotonically increases under typical workloads because jemalloc retains mapped pages after freeing them. This means:
1. Memory cap sees an ever-growing number that doesn't decrease after flow pruning
2. The cap triggers prematurely but pruning appears ineffective
3. External monitoring (RSS) shows unbounded growth

Ironically, `get_aux_counts()` (line 144) already reads `stats.allocated` for reporting, confirming the team intended to use this metric.

## Changes

| File | Line | Change |
|------|------|--------|
| `src/memory/heap_interface.cc` | 88 | `stats.mapped` → `stats.allocated` |

## Test plan

- [ ] Build with `cmake --build build` — single line change with no API impact
- [ ] Run Snort3 without rules against traffic replay, monitor `stats.allocated` vs `stats.mapped` — `stats.allocated` should stabilize after initial ramp-up
- [ ] Long-duration test (8+ hours) with memory cap set — verify memory stays bounded within ~10% of cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)