### PR TITLE
appid: parse DHCP Option 52 overloaded sname/file fields

### DIFF
--- a/src/network_inspectors/appid/service_plugins/service_bootp.cc
+++ b/src/network_inspectors/appid/service_plugins/service_bootp.cc
@@ -68,8 +68,14 @@ enum DHCP_OPTIONS
     DHCP_OPT_DOMAIN_NAME_SERVER = 6,
     DHCP_OPT_DOMAIN_NAME = 15,
     DHCP_OPT_IPADDR_LEASE_TIME = 51,
-    DHCP_OPT_DHCP_MESSAGE_TYPE =53
+    DHCP_OPT_OPTION_OVERLOAD = 52,   // RFC 2132 §9.3: sname/file used as option areas
+    DHCP_OPT_DHCP_MESSAGE_TYPE = 53
 };
+
+// RFC 2132 §9.3 overload values
+#define DHCP_OVERLOAD_FILE  1  // 'file' field holds options
+#define DHCP_OVERLOAD_SNAME 2  // 'sname' field holds options
+#define DHCP_OVERLOAD_BOTH  3  // both fields hold options
 
 struct ServiceDHCPOption
 {
@@ -80,6 +86,55 @@ struct ServiceDHCPOption
 #pragma pack()
 
 static const uint8_t zeromac[6] = { 0, 0, 0, 0, 0, 0 };
+
+// Parse a DHCP option area (standard options, or overloaded sname/file per RFC 2131 §4.1).
+// Updates option53, subnet, router, leaseTime from any options found.
+// Returns true when the end-of-options marker (0xff) is reached, false if the area is exhausted
+// without one (treated as a truncated/malformed field for overloaded areas).
+static bool parse_dhcp_options_area(const uint8_t* area, unsigned area_size,
+    int& option53, uint32_t& subnet, uint32_t& router, uint32_t& leaseTime)
+{
+    for (unsigned j = 0; j < area_size; )
+    {
+        if (area[j] == 0xff)
+            return true;
+        if (area[j] == 0x00)
+        {
+            j++;
+            continue;
+        }
+        if (j + sizeof(ServiceDHCPOption) > area_size)
+            return false;
+        const ServiceDHCPOption* op = (const ServiceDHCPOption*)(&area[j]);
+        j += sizeof(ServiceDHCPOption);
+        if (j + op->len > area_size)
+            return false;
+
+        switch (op->option)
+        {
+        case DHCP_OPT_DHCP_MESSAGE_TYPE:
+            if (op->len == 1 && area[j] == 5)
+                option53 = 1;
+            break;
+        case DHCP_OPT_SUBNET_MASK:
+            if (op->len == 4)
+                memcpy(&subnet, &area[j], sizeof(subnet));
+            break;
+        case DHCP_OPT_ROUTER:
+            if (op->len == 4)
+                memcpy(&router, &area[j], sizeof(router));
+            break;
+        case DHCP_OPT_IPADDR_LEASE_TIME:
+            if (op->len == 4)
+                memcpy(&leaseTime, &area[j], sizeof(leaseTime));
+            break;
+        default:
+            break;
+        }
+        j += op->len;
+    }
+    return false;
+}
 
 BootpServiceDetector::BootpServiceDetector(ServiceDiscovery* sd)
 {
@@ -219,6 +274,7 @@ int BootpServiceDetector::validate(AppIdDiscoveryArgs& args)
             uint32_t subnet = 0;
             uint32_t router = 0;
             uint32_t leaseTime = 0;
+            uint8_t overload = 0;
 
             for (i=sizeof(ServiceBOOTPHeader)+sizeof(uint32_t);
                 i<size;
@@ -226,6 +282,13 @@ int BootpServiceDetector::validate(AppIdDiscoveryArgs& args)
             {
                 if (data[i] == 0xff)
                 {
+                    if (overload == DHCP_OVERLOAD_SNAME || overload == DHCP_OVERLOAD_BOTH)
+                        parse_dhcp_options_area(bh->sname, sizeof(bh->sname),
+                            option53, subnet, router, leaseTime);
+                    if (overload == DHCP_OVERLOAD_FILE || overload == DHCP_OVERLOAD_BOTH)
+                        parse_dhcp_options_area(bh->file, sizeof(bh->file),
+                            option53, subnet, router, leaseTime);
+
                     const eth::EtherHdr* eh = layer::get_eth_layer(pkt);
                     if (!eh)
                         goto fail;
@@ -264,9 +327,18 @@ int BootpServiceDetector::validate(AppIdDiscoveryArgs& args)
                     }
                     break;
                 case DHCP_OPT_IPADDR_LEASE_TIME:
-                    if (op->len == 4 )
+                    if (op->len == 4)
                     {
                         memcpy(&leaseTime, &data[i], sizeof(leaseTime));
+                    }
+                    break;
+                case DHCP_OPT_OPTION_OVERLOAD:
+                    if (op->len == 1 &&
+                        (data[i] == DHCP_OVERLOAD_FILE ||
+                         data[i] == DHCP_OVERLOAD_SNAME ||
+                         data[i] == DHCP_OVERLOAD_BOTH))
+                    {
+                        overload = data[i];
                     }
                     break;
                 default:

--- a/src/network_inspectors/appid/service_plugins/test/service_bootp_test.cc
+++ b/src/network_inspectors/appid/service_plugins/test/service_bootp_test.cc
@@ -131,6 +131,203 @@ TEST(bootp_parsing_tests, dhcp_reply_multi_option_then_truncated)
     CHECK_EQUAL(APPID_NOMATCH, ret);
 }
 
+TEST_GROUP(dhcp_option_overload_helper_tests) { };
+
+TEST(dhcp_option_overload_helper_tests, parse_option_area_router_extracted)
+{
+    uint8_t area[] = { 0x03, 0x04, 0x0A, 0x64, 0x01, 0x02, 0xFF };
+    int option53 = 0;
+    uint32_t subnet = 0, router = 0, leaseTime = 0;
+
+    bool result = parse_dhcp_options_area(area, sizeof(area), option53, subnet, router, leaseTime);
+
+    CHECK_EQUAL(true, result);
+    uint32_t expected_router;
+    uint8_t ip[] = { 0x0A, 0x64, 0x01, 0x02 };
+    memcpy(&expected_router, ip, 4);
+    CHECK_EQUAL(expected_router, router);
+    CHECK_EQUAL(0, option53);
+    CHECK_EQUAL(0u, subnet);
+    CHECK_EQUAL(0u, leaseTime);
+}
+
+TEST(dhcp_option_overload_helper_tests, parse_option_area_dhcpack_type_extracted)
+{
+    uint8_t area[] = { 0x35, 0x01, 0x05, 0xFF };
+    int option53 = 0;
+    uint32_t subnet = 0, router = 0, leaseTime = 0;
+
+    bool result = parse_dhcp_options_area(area, sizeof(area), option53, subnet, router, leaseTime);
+
+    CHECK_EQUAL(true, result);
+    CHECK_EQUAL(1, option53);
+}
+
+TEST(dhcp_option_overload_helper_tests, parse_option_area_pad_bytes_skipped)
+{
+    uint8_t area[] = { 0x00, 0x00, 0x03, 0x04, 0xC0, 0xA8, 0x01, 0x01, 0xFF };
+    int option53 = 0;
+    uint32_t subnet = 0, router = 0, leaseTime = 0;
+
+    bool result = parse_dhcp_options_area(area, sizeof(area), option53, subnet, router, leaseTime);
+
+    CHECK_EQUAL(true, result);
+    uint32_t expected_router;
+    uint8_t ip[] = { 0xC0, 0xA8, 0x01, 0x01 };
+    memcpy(&expected_router, ip, 4);
+    CHECK_EQUAL(expected_router, router);
+}
+
+TEST(dhcp_option_overload_helper_tests, parse_option_area_truncated_returns_false)
+{
+    uint8_t area[] = { 0x03 };
+    int option53 = 0;
+    uint32_t subnet = 0, router = 0, leaseTime = 0;
+
+    bool result = parse_dhcp_options_area(area, sizeof(area), option53, subnet, router, leaseTime);
+
+    CHECK_EQUAL(false, result);
+}
+
+TEST(dhcp_option_overload_helper_tests, parse_option_area_truncated_value_returns_false)
+{
+    uint8_t area[] = { 0x03, 0x04, 0xC0, 0xA8 };
+    int option53 = 0;
+    uint32_t subnet = 0, router = 0, leaseTime = 0;
+
+    bool result = parse_dhcp_options_area(area, sizeof(area), option53, subnet, router, leaseTime);
+
+    CHECK_EQUAL(false, result);
+}
+
+TEST(dhcp_option_overload_helper_tests, parse_option_area_no_end_marker)
+{
+    uint8_t area[] = { 0x03, 0x04, 0xC0, 0xA8, 0x01, 0x01 };
+    int option53 = 0;
+    uint32_t subnet = 0, router = 0, leaseTime = 0;
+
+    bool result = parse_dhcp_options_area(area, sizeof(area), option53, subnet, router, leaseTime);
+
+    CHECK_EQUAL(false, result);
+}
+
+TEST_GROUP(dhcp_overload_packet_tests) { };
+
+TEST(dhcp_overload_packet_tests, dhcp_reply_option52_sname_overloaded_accepted)
+{
+    uint8_t std_opts[] = {
+        0x35, 0x01, 0x05,
+        0x34, 0x01, 0x02,
+        0xFF
+    };
+
+    uint8_t pkt[sizeof(ServiceBOOTPHeader) + 4 + sizeof(std_opts)];
+    build_bootp_header(pkt, 0x02);
+
+    ServiceBOOTPHeader* bh = reinterpret_cast<ServiceBOOTPHeader*>(pkt);
+    bh->sname[0] = 0x03;
+    bh->sname[1] = 0x04;
+    bh->sname[2] = 0x0A;  
+    bh->sname[3] = 0x64;
+    bh->sname[4] = 0x01;  
+    bh->sname[5] = 0x02;
+    bh->sname[6] = 0xFF;
+
+    add_magic_cookie(pkt + sizeof(ServiceBOOTPHeader));
+    memcpy(pkt + sizeof(ServiceBOOTPHeader) + 4, std_opts, sizeof(std_opts));
+
+    AppidChangeBits change_bits;
+    AppIdDiscoveryArgs args(pkt, sizeof(pkt), APP_ID_FROM_RESPONDER,
+        test_asd, &mock_pkt, change_bits);
+
+    int ret = detector.validate(args);
+    CHECK_EQUAL(APPID_SUCCESS, ret);
+}
+
+TEST(dhcp_overload_packet_tests, dhcp_reply_option52_file_overloaded_accepted)
+{
+    uint8_t std_opts[] = {
+        0x35, 0x01, 0x05,
+        0x34, 0x01, 0x01,
+        0xFF
+    };
+
+    uint8_t pkt[sizeof(ServiceBOOTPHeader) + 4 + sizeof(std_opts)];
+    build_bootp_header(pkt, 0x02);
+
+    ServiceBOOTPHeader* bh = reinterpret_cast<ServiceBOOTPHeader*>(pkt);
+    bh->file[0] = 0x03;
+    bh->file[1] = 0x04;
+    bh->file[2] = 0x0A;  bh->file[3] = 0x64;
+    bh->file[4] = 0x01;  bh->file[5] = 0x03;
+    bh->file[6] = 0xFF;
+
+    add_magic_cookie(pkt + sizeof(ServiceBOOTPHeader));
+    memcpy(pkt + sizeof(ServiceBOOTPHeader) + 4, std_opts, sizeof(std_opts));
+
+    AppidChangeBits change_bits;
+    AppIdDiscoveryArgs args(pkt, sizeof(pkt), APP_ID_FROM_RESPONDER,
+        test_asd, &mock_pkt, change_bits);
+
+    int ret = detector.validate(args);
+    CHECK_EQUAL(APPID_SUCCESS, ret);
+}
+
+TEST(dhcp_overload_packet_tests, dhcp_reply_option52_both_overloaded_accepted)
+{
+    uint8_t std_opts[] = {
+        0x35, 0x01, 0x05,
+        0x34, 0x01, 0x03,
+        0xFF
+    };
+
+    uint8_t pkt[sizeof(ServiceBOOTPHeader) + 4 + sizeof(std_opts)];
+    build_bootp_header(pkt, 0x02);
+
+    ServiceBOOTPHeader* bh = reinterpret_cast<ServiceBOOTPHeader*>(pkt);
+    // Router in sname
+    bh->sname[0] = 0x03; bh->sname[1] = 0x04;
+    bh->sname[2] = 0x0A; bh->sname[3] = 0x64;
+    bh->sname[4] = 0x01; bh->sname[5] = 0x02;
+    bh->sname[6] = 0xFF;
+    // Subnet mask in file
+    bh->file[0] = 0x01; bh->file[1] = 0x04;
+    bh->file[2] = 0xFF; bh->file[3] = 0xFF;
+    bh->file[4] = 0xFF; bh->file[5] = 0x00;
+    bh->file[6] = 0xFF;
+
+    add_magic_cookie(pkt + sizeof(ServiceBOOTPHeader));
+    memcpy(pkt + sizeof(ServiceBOOTPHeader) + 4, std_opts, sizeof(std_opts));
+
+    AppidChangeBits change_bits;
+    AppIdDiscoveryArgs args(pkt, sizeof(pkt), APP_ID_FROM_RESPONDER,
+        test_asd, &mock_pkt, change_bits);
+
+    int ret = detector.validate(args);
+    CHECK_EQUAL(APPID_SUCCESS, ret);
+}
+
+TEST(dhcp_overload_packet_tests, dhcp_reply_invalid_overload_value_ignored)
+{
+    uint8_t std_opts[] = {
+        0x35, 0x01, 0x05,
+        0x34, 0x01, 0x04,
+        0xFF
+    };
+
+    uint8_t pkt[sizeof(ServiceBOOTPHeader) + 4 + sizeof(std_opts)];
+    build_bootp_header(pkt, 0x02);
+    add_magic_cookie(pkt + sizeof(ServiceBOOTPHeader));
+    memcpy(pkt + sizeof(ServiceBOOTPHeader) + 4, std_opts, sizeof(std_opts));
+
+    AppidChangeBits change_bits;
+    AppIdDiscoveryArgs args(pkt, sizeof(pkt), APP_ID_FROM_RESPONDER,
+        test_asd, &mock_pkt, change_bits);
+
+    int ret = detector.validate(args);
+    CHECK_EQUAL(APPID_SUCCESS, ret);
+}
+
 int main(int argc, char** argv)
 {
     return CommandLineTestRunner::RunAllTests(argc, argv);


### PR DESCRIPTION
The bootp detector was ignoring Option 52 (Option Overload), so any DHCP options carried in the sname or file fields were silently dropped including router, DNS server, and subnet options that a compliant client would actually apply. This matters because a rogue server can use this to push configuration changes that Snort never sees (see issue #456 for a working PoC against BusyBox udhcpc).

The fix adds a second-pass parse over the overloaded fields once Option 52 is detected in the standard options area, consistent with how RFC 2131 §4.1 says clients should handle it. Unit tests cover all three overload values (1/2/3), the helper function edge cases (pad bytes, truncation), and an invalid overload value that should be ignored.