### PR TITLE
arm32: fix SIGBUS crash on unaligned IPv4 address access

### DIFF
--- a/src/codecs/ip/cd_ipv4.cc
+++ b/src/codecs/ip/cd_ipv4.cc
@@ -361,7 +361,7 @@ void Ipv4Codec::IP4AddrTests(
     uint8_t msb_src, msb_dst;
 
     // check all 32 bits ...
-    if ( iph->ip_src == iph->ip_dst )
+    if ( iph->get_src() == iph->get_dst() )
     {
         codec_event(codec, DECODE_BAD_TRAFFIC_SAME_SRCDST);
     }
@@ -376,11 +376,11 @@ void Ipv4Codec::IP4AddrTests(
     /* Loopback traffic  - don't use htonl for speed reasons -
      * s_addr is always in network order */
 #ifdef WORDS_BIGENDIAN
-    msb_src = (uint8_t)(iph->ip_src >> 24);
-    msb_dst = (uint8_t)(iph->ip_dst >> 24);
+    msb_src = (uint8_t)(iph->get_src() >> 24);
+    msb_dst = (uint8_t)(iph->get_dst() >> 24);
 #else
-    msb_src = (uint8_t)(iph->ip_src & 0xff);
-    msb_dst = (uint8_t)(iph->ip_dst & 0xff);
+    msb_src = (uint8_t)(iph->get_src() & 0xff);
+    msb_dst = (uint8_t)(iph->get_dst() & 0xff);
 #endif
     // check the msb ...
     if ( (msb_src == ip::IP4_LOOPBACK) || (msb_dst == ip::IP4_LOOPBACK) )

--- a/src/connectors/std_connector/test/std_connector_test.cc
+++ b/src/connectors/std_connector/test/std_connector_test.cc
@@ -34,7 +34,7 @@
 StdConnectorBuffer::StdConnectorBuffer(const char*) {}
 StdConnectorBuffer::~StdConnectorBuffer() {}
 void StdConnectorBuffer::start() {}
-Ring2::Writer StdConnectorBuffer::acquire(unsigned long) { return Ring2(0).writer(); }
+Ring2::Writer StdConnectorBuffer::acquire(size_t) { return Ring2(0).writer(); }
 bool StdConnectorBuffer::release(Ring2::Writer const&) { return false; }
 
 using namespace snort;

--- a/src/framework/test/mp_data_bus_test.cc
+++ b/src/framework/test/mp_data_bus_test.cc
@@ -84,7 +84,7 @@ void show_stats(PegCount*, const PegInfo*, unsigned, const char*)
     mock().actualCall("show_stats");
 }
 void show_stats(PegCount*, const PegInfo*, const std::vector<unsigned>&, const char*, FILE*) { }
-void show_stats(unsigned long*, PegInfo const*, char const*) {}
+void show_stats(PegCount*, const PegInfo*, const char*) {}
 
 bool ControlConn::respond(const char*, ...) { return true; }
 

--- a/src/network_inspectors/appid/detector_plugins/test/detector_plugins_mock.h
+++ b/src/network_inspectors/appid/detector_plugins/test/detector_plugins_mock.h
@@ -266,7 +266,7 @@ bool HostPatternMatchers::scan_url(const uint8_t*, size_t, AppId&, AppId&, bool*
 void AppIdModule::reset_stats() {}
 bool AppIdInspector::configure(snort::SnortConfig*) { return true; }
 void appid_log(const snort::Packet*, unsigned char, char const*, ...) { }
-void HostPatternMatchers::add_host_pattern(unsigned char const*, unsigned long, unsigned char, int, int, HostPatternType, bool, bool) {}
+void HostPatternMatchers::add_host_pattern(const uint8_t*, size_t, uint8_t, AppId, AppId, HostPatternType, bool, bool) {}
 
 #ifndef SIP_UNIT_TEST
 snort::SearchTool::SearchTool(bool, const char*) { }

--- a/src/protocols/ipv4.h
+++ b/src/protocols/ipv4.h
@@ -100,10 +100,10 @@ struct IP4Hdr
 
     /* booleans */
     inline bool is_src_broadcast() const
-    { return ip_src == IP4_BROADCAST; }
+    { return get_src() == IP4_BROADCAST; }
 
     inline bool is_dst_broadcast() const
-    { return ip_dst == IP4_BROADCAST; }
+    { return get_dst() == IP4_BROADCAST; }
 
     inline bool has_options() const
     { return hlen() > 20; }
@@ -121,11 +121,22 @@ struct IP4Hdr
     inline uint16_t raw_csum() const
     { return ip_csum; }
 
+#if defined(__arm__) && !defined(__aarch64__)
+    // ARM32: ip_src/ip_dst may be 2-byte aligned after the 14-byte Ethernet
+    // header on a 4-byte-aligned libpcap buffer. Use __builtin_memcpy so the
+    // compiler emits byte-safe loads instead of a faulting LDR instruction.
+    inline uint32_t get_src() const
+    { uint32_t v; __builtin_memcpy(&v, &ip_src, 4); return v; }
+
+    inline uint32_t get_dst() const
+    { uint32_t v; __builtin_memcpy(&v, &ip_dst, 4); return v; }
+#else
     inline uint32_t get_src() const
     { return ip_src; }
 
     inline uint32_t get_dst() const
     { return ip_dst; }
+#endif
 
     /*  setters  */
     inline void set_hlen(uint8_t value)

--- a/src/sfip/sf_ip.cc
+++ b/src/sfip/sf_ip.cc
@@ -314,7 +314,7 @@ SfIpRet SfIp::set(const void* src, int fam)
     {
         ip32[0] = ip32[1] = ip16[4] = 0;
         ip16[5] = 0xffff;
-        ip32[3] = *(const uint32_t*)src;
+        memcpy(&ip32[3], src, sizeof(ip32[3]));
     }
     else if (family == AF_INET6)
         memcpy(ip8, src, 16);


### PR DESCRIPTION
## Problem

On 32-bit ARM (ARMv7), Snort 3 crashes with SIGBUS during packet processing. The root cause is unaligned memory access when reading the source and destination IPv4 addresses from a packet header.

A `libpcap` capture buffer is 4-byte aligned. The Ethernet header is 14 bytes, which places the start of the IPv4 header at a 2-byte boundary. The `ip_src` and `ip_dst` fields sit at offsets 12 and 16 within that header, both 2-byte aligned in the buffer, but the ARMv7 architecture requires natural (4-byte) alignment for 32-bit loads. Any direct `uint32_t` read of those fields issues a faulting `LDR` instruction and the kernel delivers `SIGBUS`.

The same misalignment issue exists in `SfIp::set()` when storing an IPv4-mapped address into the internal `ip32` array.

Fixes #458.

## Changes

**Runtime fixes**

- `src/sfip/sf_ip.cc` --> replace misaligned `*(const uint32_t*)src` cast with `memcpy` when storing an IPv4-mapped address.
- `src/protocols/ipv4.h` --> add ARM32-conditional `get_src()` / `get_dst()` accessors that use `__builtin_memcpy`, so the compiler emits byte-safe loads instead of a faulting `LDR`; route `is_src_broadcast()` and `is_dst_broadcast()` through those accessors.
- `src/codecs/ip/cd_ipv4.cc` --> replace five direct `ip_src` / `ip_dst` reads in `IP4AddrTests()` with `get_src()` / `get_dst()` calls.

**Unit-test fixes**

Three test mocks had type mismatches that happen to be harmless on 64-bit platforms (where `size_t`, `unsigned long`, and `uint64_t` are all 64 bits) but cause compile errors on arm/v7 under the ILP32 ABI (`size_t` = `uint32_t`, `PegCount` = `uint64_t`, both distinct from `unsigned long`):

- `detector_plugins_mock.h` --> corrected `add_host_pattern` stub signature.
- `std_connector_test.cc` --> corrected `StdConnectorBuffer::acquire` parameter type (`size_t`).
- `mp_data_bus_test.cc` --> corrected `show_stats` overload parameter type (`PegCount*`).

## Testing

All 162 unit tests pass on all three platforms with no regressions:

| Platform       |Tests | Result      |
|---------------|------|---------------|
| linux/arm/v7 | 158 | 100% passed |
| linux/arm64  | 162 | 100% passed |
| linux/amd64 | 162 | 100% passed |

(arm/v7 runs 158 tests because 4 tests in the suite are gated on 64-bit types and are skipped on ILP32.)