### PR TITLE
docker: add multi-platform Alpine image, CI pipeline, and test suite

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,70 @@
+# .dockerignore — keep the build context small and fast
+#
+# Docker sends the entire build context directory to the daemon before
+# building. Excluding large / unnecessary files speeds up every build.
+
+# ── Version control ───────────────────────────────────────────────────────────
+.git
+.gitignore
+.gitmodules
+.github
+
+# ── CI / tooling ─────────────────────────────────────────────────────────────
+.travis.yml
+.circleci
+Jenkinsfile
+*.sh.bak
+
+# ── Build artefacts (local cmake / make output) ───────────────────────────────
+build/
+build-*/
+*.o
+*.a
+*.so
+*.lo
+*.la
+CMakeFiles/
+CMakeCache.txt
+cmake_install.cmake
+Makefile
+install_manifest.txt
+
+# ── Documentation ────────────────────────────────────────────────────────────
+doc/
+docs/
+*.md
+*.rst
+*.pdf
+*.png
+*.mmd
+DOCKER.md
+LICENSE
+COPYING
+ChangeLog
+AUTHORS
+THANKS
+README*
+
+# ── Test artefacts ────────────────────────────────────────────────────────────
+test_issue*
+run_sigterm_test.py
+test_sigterm.sh
+issue*_analysis.md
+*_validation_summary.md
+trivy-reports/
+
+# ── IDE / editor files ────────────────────────────────────────────────────────
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+Thumbs.db
+
+# ── Logs ─────────────────────────────────────────────────────────────────────
+*.log
+logs/
+
+# ── Snort pre-built tree (if present from a local build) ─────────────────────
+snort3/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,202 @@
+name: Docker Build, Test & Push
+
+# Per-platform pipeline (all platforms run in parallel):
+#   1. docker build  — unit tests run inside the Dockerfile (make check)
+#   2. functional tests (test-docker.sh sections A B C, T01-T36)
+#   3. Trivy scan (test-docker.sh section E, T38-T40)
+#   4. push to GHCR  — only reached if all of the above pass
+#
+# After all platforms pass:
+#   5. merge per-platform digests into a single multi-arch manifest
+#
+# Triggers:
+#   push / tag / workflow_dispatch  → build + test + push + manifest
+#   pull_request                    → build + test only (no push, no manifest)
+on:
+  push:
+    branches: [master, main]
+    tags:     ['3.*']
+    paths:
+      - Dockerfile
+      - scripts/**
+      - .github/workflows/docker.yml
+  pull_request:
+    branches: [master, main]
+    paths:
+      - Dockerfile
+      - scripts/**
+      - .github/workflows/docker.yml
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  # Override the image name via the DOCKER_IMAGE repository variable.
+  IMAGE: ${{ vars.DOCKER_IMAGE || format('{0}/snort3', github.repository_owner) }}
+
+jobs:
+  build-test-push:
+    name: ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+
+    permissions:
+      contents:        read
+      packages:        write
+      security-events: write
+
+    strategy:
+      fail-fast: false  # a failure on one platform does not cancel others
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner:   ubuntu-latest
+            tag:      amd64
+
+          - platform: linux/arm64
+            runner:   ubuntu-24.04-arm
+            tag:      arm64
+
+          - platform: linux/ppc64le
+            runner:   ubuntu-latest
+            tag:      ppc64le
+
+          - platform: linux/arm/v7
+            runner:   ubuntu-latest
+            tag:      armv7
+
+          - platform: linux/386
+            runner:   ubuntu-latest
+            tag:      386
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        if: matrix.runner == 'ubuntu-latest' && matrix.platform != 'linux/amd64'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: ${{ matrix.platform }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Step 1: build and load into the local daemon for testing.
+      # Unit tests run inside the Dockerfile (make check). Build fails if they fail.
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context:    .
+          platforms:  ${{ matrix.platform }}
+          load:       true
+          tags:       snort3:${{ matrix.tag }}
+          cache-from: type=gha,scope=build-${{ matrix.tag }}
+          cache-to:   type=gha,mode=max,scope=build-${{ matrix.tag }}
+
+      # Step 2: functional tests against the locally loaded image.
+      # Covers image metadata, binary/library presence, config validation,
+      # pcap replay, alert rule firing, and volume permissions (T01-T36).
+      - name: Functional tests
+        run: |
+          bash scripts/test-docker.sh \
+            --platform ${{ matrix.platform }} \
+            --image    snort3:${{ matrix.tag }} \
+            --sections "A B C" \
+            --skip-build \
+            --skip-trivy
+
+      # Step 3: Trivy vulnerability and secret scan (T38-T40).
+      # Fails if any CRITICAL or HIGH CVE or embedded secret is found.
+      - name: Trivy scan
+        run: |
+          bash scripts/test-docker.sh \
+            --platform ${{ matrix.platform }} \
+            --image    snort3:${{ matrix.tag }} \
+            --sections "E" \
+            --skip-build
+
+      # Step 4: push to GHCR — only reached if build, tests, and Trivy all passed.
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push image
+        id: push
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context:    .
+          platforms:  ${{ matrix.platform }}
+          push:       true
+          tags:       ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ matrix.tag }}
+          cache-from: type=gha,scope=build-${{ matrix.tag }}
+
+      - name: Save digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p /tmp/digests
+          echo "${{ steps.push.outputs.digest }}" > /tmp/digests/${{ matrix.tag }}.txt
+
+      - name: Upload digest artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name:              digest-${{ matrix.tag }}
+          path:              /tmp/digests/${{ matrix.tag }}.txt
+          if-no-files-found: error
+          retention-days:    1
+
+  # Merge all per-platform images into a single multi-arch manifest.
+  # Only runs after every platform job above has passed.
+  manifest:
+    name: Merge multi-arch manifest
+    runs-on: ubuntu-latest
+    needs: build-test-push
+    if: github.event_name != 'pull_request'
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Download all digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern:        digest-*
+          merge-multiple: true
+          path:           /tmp/digests
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifest
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE }}"
+
+          SOURCES=""
+          for f in /tmp/digests/*.txt; do
+            digest="$(cat "$f")"
+            SOURCES="$SOURCES ${IMAGE}@${digest}"
+          done
+
+          docker buildx imagetools create \
+            --tag "${IMAGE}:${GITHUB_REF_NAME}" \
+            --tag "${IMAGE}:latest" \
+            $SOURCES
+
+      - name: Inspect manifest
+        run: docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,201 @@
+# syntax=docker/dockerfile:1
+#
+# Snort 3 multi-platform Alpine image
+#
+# Platforms:
+#   linux/amd64    Vectorscan + LuaJIT
+#   linux/arm64    Vectorscan + LuaJIT
+#   linux/ppc64le  Vectorscan, no LuaJIT  (no upstream LuaJIT PPC64 backend)
+#   linux/arm/v7   AC-BNFA  + LuaJIT
+#   linux/386      AC-BNFA  + LuaJIT
+#
+# Build:
+#   docker build --platform linux/amd64 -t snort3:alpine .
+#   docker buildx build --platform linux/amd64,linux/arm64,linux/ppc64le,linux/arm/v7,linux/386 \
+#     -t yourrepo/snort3:alpine --push .
+#
+# SNORT_REPO/SNORT_BRANCH point to the arm32 fix branch (snort3/snort3#459, pending merge).
+# Switch back to upstream once merged:
+#   --build-arg SNORT_REPO=https://github.com/snort3/snort3.git --build-arg SNORT_BRANCH=<tag>
+#
+# Run:
+#   docker run --rm --network host --cap-add NET_ADMIN --cap-add NET_RAW \
+#     -v $(pwd)/snort.lua:/snort3/etc/snort/snort.lua:ro \
+#     -v $(pwd)/rules:/snort3/etc/rules:ro \
+#     -v snort-logs:/var/log/snort \
+#     snort3:alpine -c /snort3/etc/snort/snort.lua -i eth0 -A fast
+
+ARG ALPINE_VERSION=3.21
+ARG SNORT_VERSION=3.12.1.0
+
+# Stage 1: build tools and -dev headers, shared by all builder stages
+FROM alpine:${ALPINE_VERSION} AS toolchain
+
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \
+    apk add --update-cache \
+        build-base \
+        cmake \
+        autoconf \
+        automake \
+        libtool \
+        bison \
+        flex \
+        flex-dev \
+        git \
+        curl \
+        pkgconf \
+        python3 \
+        libpcap-dev \
+        hwloc-dev \
+        openssl-dev \
+        zlib-dev \
+        pcre2-dev \
+        xz-dev \
+        libdnet-dev \
+        libtirpc-dev \
+        cpputest
+
+# Vectorscan is only packaged for amd64, arm64, and ppc64le
+RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \
+    if [ "$TARGETARCH" = "amd64" ] || \
+       [ "$TARGETARCH" = "arm64" ] || \
+       [ "$TARGETARCH" = "ppc64le" ]; then \
+        apk add --update-cache vectorscan-dev; \
+    fi
+
+# Stage 2: LuaJIT and libdaq (not in Alpine packages)
+# LuaJIT built from v2.1 branch — fixes CVE-2024-25176/25177/25178 in Alpine's packaged r0.
+# ppc64le falls back to the Alpine community port (no upstream LuaJIT PPC64 backend).
+FROM toolchain AS deps-builder
+
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+RUN if [ "$TARGETARCH" = "amd64" ] || \
+       [ "$TARGETARCH" = "arm64" ] || \
+       [ "$TARGETARCH" = "arm" ]   || \
+       [ "$TARGETARCH" = "386" ];  then \
+        git clone --depth 1 --branch v2.1 \
+            https://github.com/LuaJIT/LuaJIT.git /tmp/luajit \
+     && cd /tmp/luajit \
+     && make -j$(nproc) PREFIX=/usr/local \
+     && make install PREFIX=/usr/local \
+     && rm -rf /tmp/luajit; \
+    else \
+        apk add --no-cache luajit-dev; \
+    fi
+
+RUN git clone --depth 1 https://github.com/snort3/libdaq.git /tmp/libdaq \
+ && cd /tmp/libdaq \
+ && ./bootstrap \
+ && ./configure --prefix=/usr/local \
+ && make -j$(nproc) install \
+ && rm -rf /tmp/libdaq
+
+# Stage 3: Snort 3 build and unit tests
+FROM deps-builder AS snort-builder
+
+ARG SNORT_VERSION
+# Defaults to the arm32 SIGBUS fix branch (snort3/snort3#459) until merged upstream.
+# Override to switch back: --build-arg SNORT_REPO=https://github.com/snort3/snort3.git --build-arg SNORT_BRANCH=<tag>
+ARG SNORT_REPO=https://github.com/ssam18/snort3.git
+ARG SNORT_BRANCH=fix/arm32-sigbus-unaligned-ip-access
+ARG TARGETARCH
+
+RUN git clone --depth 1 --branch "$SNORT_BRANCH" \
+        "$SNORT_REPO" /tmp/snort3
+
+RUN cd /tmp/snort3 \
+ && if [ "$TARGETARCH" = "amd64" ] || \
+       [ "$TARGETARCH" = "arm64" ] || \
+       [ "$TARGETARCH" = "arm" ]   || \
+       [ "$TARGETARCH" = "386" ];  then \
+        ./configure_cmake.sh \
+            --prefix=/snort3 \
+            --build-type=MinSizeRel \
+            --without-libml \
+            --disable-docs \
+            --disable-gdb \
+            --enable-unit-tests \
+            --with-luajit-includes=/usr/local/include/luajit-2.1 \
+            --with-luajit-libraries=/usr/local/lib; \
+    else \
+        ./configure_cmake.sh \
+            --prefix=/snort3 \
+            --build-type=MinSizeRel \
+            --without-libml \
+            --disable-docs \
+            --disable-gdb \
+            --enable-unit-tests; \
+    fi \
+ && cd build \
+ && make -j$(nproc) install \
+ && make -j$(nproc) check \
+ && rm -rf /tmp/snort3
+
+RUN find /snort3/bin /snort3/lib /usr/local/lib -type f \
+        \( -name "*.so*" -o -name "snort" \) \
+        -exec strip --strip-unneeded {} + 2>/dev/null || true
+
+# Stage 4: minimal runtime image, no build tools or headers
+FROM alpine:${ALPINE_VERSION}
+
+ARG SNORT_VERSION
+ARG TARGETARCH
+
+LABEL org.opencontainers.image.title="snort3" \
+      org.opencontainers.image.description="Snort 3 IDS - minimal Alpine image" \
+      org.opencontainers.image.version="${SNORT_VERSION}" \
+      org.opencontainers.image.source="https://github.com/snort3/snort3" \
+      org.opencontainers.image.base.name="alpine:3.21"
+
+RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \
+    apk add --update-cache \
+        bash \
+        libpcap \
+        hwloc \
+        libssl3 \
+        libcrypto3 \
+        zlib \
+        pcre2 \
+        xz-libs \
+        libdnet \
+        libtirpc \
+        libuuid \
+        libstdc++ \
+        libgcc
+
+RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \
+    if [ "$TARGETARCH" = "amd64" ] || \
+       [ "$TARGETARCH" = "arm64" ] || \
+       [ "$TARGETARCH" = "ppc64le" ]; then \
+        apk add --update-cache vectorscan; \
+    fi
+
+# source-built LuaJIT lands in /usr/local/lib; Alpine package lands in /usr/lib — copy whichever
+RUN --mount=type=bind,from=snort-builder,source=/usr/local/lib,target=/build/local/lib \
+    --mount=type=bind,from=snort-builder,source=/usr/lib,target=/build/usr/lib \
+    find /build/local/lib /build/usr/lib -name 'libluajit-5.1.so*' \
+         -exec cp -P {} /usr/local/lib/ \; 2>/dev/null || true
+
+COPY --link --from=snort-builder /usr/local/lib/libdaq.so*  /usr/local/lib/
+COPY --link --from=snort-builder /usr/local/lib/daq/        /usr/local/lib/daq/
+COPY --link --from=snort-builder /snort3 /snort3
+
+ENV LD_LIBRARY_PATH=/usr/local/lib:/snort3/lib
+ENV PATH=/snort3/bin:$PATH
+
+RUN adduser -D -h /home/snorty snorty \
+ && mkdir -p /var/log/snort /snort3/etc/rules \
+ && chown -R snorty:snorty /var/log/snort /snort3/etc/rules
+
+VOLUME ["/snort3/etc/rules", "/var/log/snort"]
+
+USER snorty
+WORKDIR /home/snorty
+
+ENTRYPOINT ["snort"]
+CMD ["--version"]

--- a/scripts/test-docker.sh
+++ b/scripts/test-docker.sh
@@ -1,0 +1,662 @@
+#!/usr/bin/env bash
+# test-docker.sh — build and test the Snort 3 Alpine image (T01–T40)
+#
+# Usage:
+#   bash scripts/test-docker.sh                          # interactive
+#   bash scripts/test-docker.sh --platform linux/amd64  # non-interactive
+#
+# Options:
+#   --platform PLAT         target platform, e.g. linux/amd64
+#   --image IMAGE           override the auto-derived image tag
+#   --sections "A B C D E"  run only these sections (A=Metadata B=Binary C=Functional D=Live E=Trivy)
+#   --skip-build            skip build; fail if image is missing
+#   --skip-trivy            skip section E
+#   --skip-live             skip section D (default)
+#   --live                  include section D (live NIC test)
+#   --iface IFACE           interface for T37 (default: eth0)
+#   -h, --help              show this help
+#
+# Sections A B C E run by default. Section D requires --live. Trivy auto-installs if missing.
+# Exit code: 0 = all passed, 1 = one or more failed
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+CYAN='\033[0;36m'; BOLD='\033[1m'; RESET='\033[0m'; GREY='\033[0;37m'
+DIM='\033[2m'
+
+# "docker-platform|tag|description|regex-engine"
+PLATFORM_ENTRIES=(
+    "linux/amd64|amd64|Intel / AMD 64-bit (x86_64)|Vectorscan enabled"
+    "linux/arm64|arm64|Apple M*, AWS Graviton, RPi 64-bit|Vectorscan enabled"
+    "linux/ppc64le|ppc64le|IBM POWER little-endian|Vectorscan enabled"
+    "linux/arm/v7|armv7|Raspberry Pi 32-bit OS / embedded ARM|AC-BNFA fallback"
+    "linux/386|386|Intel / AMD 32-bit|AC-BNFA fallback"
+    "native||Current machine architecture (auto-detect)|auto"
+)
+
+OPT_PLATFORM=""          # set by --platform or picker
+OPT_IMAGE_OVERRIDE=""    # set by --image
+OPT_SECTIONS=""          # set by --sections
+OPT_SKIP_BUILD=false
+OPT_SKIP_TRIVY=false
+OPT_SKIP_LIVE=false      # if true, overrides picker default for D
+OPT_LIVE=false           # --live explicitly requested
+OPT_IFACE="${SNORT_IFACE:-eth0}"
+OPT_TIMEOUT=""           # per-test timeout in seconds; 0 = no limit; auto-set below
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --platform)   OPT_PLATFORM="$2";        shift 2 ;;
+        --image)      OPT_IMAGE_OVERRIDE="$2";  shift 2 ;;
+        --sections)   OPT_SECTIONS="$2";        shift 2 ;;
+        --skip-build) OPT_SKIP_BUILD=true;      shift ;;
+        --skip-trivy) OPT_SKIP_TRIVY=true;      shift ;;
+        --skip-live)  OPT_SKIP_LIVE=true;       shift ;;
+        --live)       OPT_LIVE=true;            shift ;;
+        --iface)      OPT_IFACE="$2";           shift 2 ;;
+        --timeout)    OPT_TIMEOUT="$2";         shift 2 ;;
+        -h|--help)
+            sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *) echo -e "${RED}Unknown option: $1${RESET}" >&2; exit 1 ;;
+    esac
+done
+
+divider() {
+    echo ""
+    echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
+    echo -e "${BOLD}  $*${RESET}"
+    echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
+}
+log() { echo -e "${CYAN}[test-docker]${RESET} $*"; }
+
+platform_to_tag() {
+    # linux/arm/v7 → armv7,  linux/amd64 → amd64, etc.
+    local plat="$1"
+    for entry in "${PLATFORM_ENTRIES[@]}"; do
+        local p t
+        p="$(echo "$entry" | cut -d'|' -f1)"
+        t="$(echo "$entry" | cut -d'|' -f2)"
+        [[ "$p" == "$plat" ]] && { echo "$t"; return; }
+    done
+    echo "$plat" | sed 's|linux/||; s|/||g'
+}
+
+divider "Step 1 — Choose a platform"
+
+if [[ -n "$OPT_PLATFORM" ]]; then
+    PLATFORM="$OPT_PLATFORM"
+    log "Platform supplied via flag: ${BOLD}$PLATFORM${RESET}"
+else
+    echo ""
+    echo -e "  ${BOLD}Available build platforms:${RESET}"
+    echo ""
+    local_i=1
+    for entry in "${PLATFORM_ENTRIES[@]}"; do
+        p="$(echo "$entry" | cut -d'|' -f1)"
+        d="$(echo "$entry" | cut -d'|' -f3)"
+        n="$(echo "$entry" | cut -d'|' -f4)"
+        printf "  ${BOLD}%d)${RESET}  %-20s  %-42s  ${DIM}%s${RESET}\n" \
+               "$local_i" "$p" "$d" "$n"
+        (( local_i++ )) || true
+    done
+    echo ""
+
+    while true; do
+        printf "  Select platform [1-%d]: " "${#PLATFORM_ENTRIES[@]}"
+        read -r _choice
+        if [[ "$_choice" =~ ^[0-9]+$ ]] && \
+           (( _choice >= 1 && _choice <= ${#PLATFORM_ENTRIES[@]} )); then
+            PLATFORM="$(echo "${PLATFORM_ENTRIES[$(( _choice - 1 ))]}" | cut -d'|' -f1)"
+            break
+        fi
+        echo -e "  ${YELLOW}Please enter a number between 1 and ${#PLATFORM_ENTRIES[@]}${RESET}"
+    done
+    log "Selected: ${BOLD}$PLATFORM${RESET}"
+fi
+
+if [[ -n "$OPT_IMAGE_OVERRIDE" ]]; then
+    IMAGE="$OPT_IMAGE_OVERRIDE"
+    log "Image tag overridden: ${BOLD}$IMAGE${RESET}"
+elif [[ "$PLATFORM" == "native" ]]; then
+    PLATFORM=""
+    IMAGE="snort3:alpine-native"
+    log "Derived image tag: ${BOLD}$IMAGE${RESET}"
+else
+    IMAGE="snort3:alpine-$(platform_to_tag "$PLATFORM")"
+    log "Derived image tag: ${BOLD}$IMAGE${RESET}"
+fi
+
+divider "Step 2 — Choose test sections"
+
+_SECTION_FLAGS_PROVIDED=false
+[[ -n "$OPT_SECTIONS" || "$OPT_SKIP_TRIVY" == true || \
+   "$OPT_SKIP_LIVE" == true || "$OPT_LIVE" == true ]] && _SECTION_FLAGS_PROVIDED=true
+
+RUN_A=true; RUN_B=true; RUN_C=true; RUN_D=false; RUN_E=true  # defaults
+
+if $_SECTION_FLAGS_PROVIDED; then
+    $OPT_SKIP_TRIVY && RUN_E=false
+    $OPT_LIVE       && RUN_D=true
+    $OPT_SKIP_LIVE  && RUN_D=false
+
+    if [[ -n "$OPT_SECTIONS" ]]; then
+        RUN_A=false; RUN_B=false; RUN_C=false; RUN_D=false; RUN_E=false
+        _SEC="${OPT_SECTIONS^^}"
+        [[ "$_SEC" == *A* ]] && RUN_A=true
+        [[ "$_SEC" == *B* ]] && RUN_B=true
+        [[ "$_SEC" == *C* ]] && RUN_C=true
+        [[ "$_SEC" == *D* ]] && RUN_D=true
+        [[ "$_SEC" == *E* ]] && RUN_E=true
+    fi
+
+    echo ""
+    _active=""
+    $RUN_A && _active+=" A"
+    $RUN_B && _active+=" B"
+    $RUN_C && _active+=" C"
+    $RUN_D && _active+=" D"
+    $RUN_E && _active+=" E"
+    log "Sections from flags:${BOLD}${_active}${RESET}"
+else
+    echo ""
+    echo -e "  ${BOLD}Available test sections:${RESET}"
+    echo ""
+    echo -e "  ${BOLD}A)${RESET}  Image Metadata        T01–T08   image inspect, size, entrypoint, labels"
+    echo -e "  ${BOLD}B)${RESET}  Binary & Library      T09–T24   snort binary, ldd, DAQ modules, .so files"
+    echo -e "  ${BOLD}C)${RESET}  Functional            T25–T36   config validation, pcap replay, alert rules"
+    echo -e "  ${BOLD}D)${RESET}  Live Interface        T37       requires host network + physical NIC"
+    echo -e "  ${BOLD}E)${RESET}  Trivy Security Scan   T38–T40   CVE + secret scan  ${DIM}(auto-installs trivy)${RESET}"
+    echo ""
+    echo -e "  ${DIM}Default (press Enter) = A B C E  — everything except live interface${RESET}"
+    echo ""
+    printf "  Enter sections to run (e.g. A B C E): "
+    read -r _input
+
+    if [[ -z "$_input" ]]; then
+        log "Using defaults: ${BOLD}A B C E${RESET}"
+    else
+        RUN_A=false; RUN_B=false; RUN_C=false; RUN_D=false; RUN_E=false
+        _input="${_input^^}"
+        [[ "$_input" == *A* ]] && RUN_A=true
+        [[ "$_input" == *B* ]] && RUN_B=true
+        [[ "$_input" == *C* ]] && RUN_C=true
+        [[ "$_input" == *D* ]] && RUN_D=true
+        [[ "$_input" == *E* ]] && RUN_E=true
+
+        _active=""
+        $RUN_A && _active+=" A"
+        $RUN_B && _active+=" B"
+        $RUN_C && _active+=" C"
+        $RUN_D && _active+=" D"
+        $RUN_E && _active+=" E"
+        log "Selected sections:${BOLD}${_active}${RESET}"
+    fi
+fi
+
+# Warn if D selected without --live
+if $RUN_D; then
+    echo -e "  ${YELLOW}Note:${RESET} Section D (live interface) will use iface=${BOLD}${OPT_IFACE}${RESET}."
+    echo -e "  ${YELLOW}Note:${RESET} Test will fail if the interface does not exist or lacks NET_ADMIN."
+fi
+
+# QEMU arches are slow; give them a longer timeout. Override via --timeout or SNORT_TEST_TIMEOUT.
+if [[ -n "$OPT_TIMEOUT" ]]; then
+    TEST_TIMEOUT="$OPT_TIMEOUT"
+elif [[ -n "${SNORT_TEST_TIMEOUT:-}" ]]; then
+    TEST_TIMEOUT="$SNORT_TEST_TIMEOUT"
+elif [[ "$PLATFORM" == *arm/v7* || "$PLATFORM" == *386* ]]; then
+    TEST_TIMEOUT=600   # 32-bit QEMU is very slow
+elif [[ "$PLATFORM" == *ppc64le* || "$PLATFORM" == *s390x* || "$PLATFORM" == *riscv64* ]]; then
+    TEST_TIMEOUT=300   # 64-bit QEMU
+else
+    TEST_TIMEOUT=60    # native
+fi
+log "Per-test timeout: ${BOLD}${TEST_TIMEOUT}s${RESET}"
+
+divider "Step 3 — Build / verify image"
+
+if docker image inspect "$IMAGE" &>/dev/null; then
+    log "Image ${BOLD}$IMAGE${RESET} already present locally — skipping build."
+elif $OPT_SKIP_BUILD; then
+    echo -e "${RED}ERROR${RESET}: Image '$IMAGE' not found and --skip-build was set." >&2
+    exit 1
+else
+    _PFLAG=""
+    [[ -n "$PLATFORM" ]] && _PFLAG="--platform $PLATFORM"
+
+    log "Image not found — building ${BOLD}$IMAGE${RESET}${PLATFORM:+ for $PLATFORM} ..."
+    echo -e "  ${YELLOW}Note:${RESET} First build on a QEMU-emulated platform takes ~30 min."
+    echo ""
+
+    # needed for --mount=type=cache; Docker >=23 enables this by default
+    export DOCKER_BUILDKIT=1
+
+    docker build \
+        $_PFLAG \
+        --progress=plain \
+        -t "$IMAGE" \
+        "$REPO_ROOT"
+
+    log "Build complete."
+fi
+
+PASS=0; FAIL=0; SKIP=0
+declare -a PASSED_TESTS=()
+declare -a FAILED_TESTS=()
+declare -a SKIPPED_TESTS=()
+
+# run_test ID DESC EXPECT CMD... — expect: EXIT_0 | EMPTY | NON_EMPTY | grep-E pattern
+run_test() {
+    local id="$1" desc="$2" expect="$3"; shift 3
+    local output exit_code=0
+
+    printf "  ${BOLD}%-5s${RESET} %s ... " "$id" "$desc"
+    if [[ "${TEST_TIMEOUT:-0}" -gt 0 ]]; then
+        output="$(timeout --kill-after=15 "${TEST_TIMEOUT}" "$@" 2>&1)" || exit_code=$?
+        if [[ $exit_code -eq 124 || $exit_code -eq 137 ]]; then
+            echo -e "${YELLOW}TIMEOUT${RESET}  (>${TEST_TIMEOUT}s — killed)"
+            (( FAIL++ )) || true
+            FAILED_TESTS+=("$id: $desc  [timed out after ${TEST_TIMEOUT}s]")
+            return
+        fi
+    else
+        output="$("$@" 2>&1)" || exit_code=$?
+    fi
+
+    local result=PASS
+    case "$expect" in
+        EXIT_0)    [[ $exit_code -eq 0 ]] || result=FAIL ;;
+        EMPTY)     [[ -z "$output" ]]      || result=FAIL ;;
+        NON_EMPTY) [[ -n "$output" ]]      || result=FAIL ;;
+        *)         echo "$output" | grep -qE "$expect" || result=FAIL ;;
+    esac
+
+    if [[ "$result" == PASS ]]; then
+        echo -e "${GREEN}PASS${RESET}"
+        (( PASS++ )) || true
+        PASSED_TESTS+=("$id: $desc")
+    else
+        echo -e "${RED}FAIL${RESET}"
+        echo -e "    ${GREY}expect : $expect${RESET}"
+        echo -e "    ${GREY}output : $(echo "$output" | head -5 | sed 's/^/             /')${RESET}"
+        (( FAIL++ )) || true
+        FAILED_TESTS+=("$id: $desc")
+    fi
+}
+
+run_test_sh() {
+    local id="$1" desc="$2" expect="$3" script="$4"
+    local _pflag=()
+    [[ -n "$PLATFORM" ]] && _pflag=("--platform" "$PLATFORM")
+    run_test "$id" "$desc" "$expect" \
+        docker run --rm --stop-timeout 5 "${_pflag[@]}" --entrypoint sh "$IMAGE" -c "$script"
+}
+
+skip_test() {
+    printf "  ${BOLD}%-5s${RESET} %s ... ${GREY}SKIP${RESET}  %s\n" "$1" "$2" "$3"
+    (( SKIP++ )) || true
+    SKIPPED_TESTS+=("$1: $2")
+}
+
+if $RUN_A; then
+    divider "Section A — Image Metadata (T01–T08)"
+
+    run_test T01 "Image exists locally" EXIT_0 \
+        docker image inspect "$IMAGE"
+
+    printf "  ${BOLD}%-5s${RESET} %s ... " "T02" "Image size < 80 MB"
+    _sz=$(docker image inspect "$IMAGE" --format '{{.Size}}' 2>/dev/null || echo 0)
+    if (( _sz < 83886080 )); then
+        echo -e "${GREEN}PASS${RESET}  ($(( _sz / 1048576 )) MB)"
+        (( PASS++ )) || true; PASSED_TESTS+=("T02: Image size < 80 MB")
+    else
+        echo -e "${RED}FAIL${RESET}  ($(( _sz / 1048576 )) MB — expected < 80 MB)"
+        (( FAIL++ )) || true; FAILED_TESTS+=("T02: Image size < 80 MB")
+    fi
+
+    run_test T03 "Entrypoint is [\"snort\"]" '^\["snort"\]$' \
+        docker image inspect "$IMAGE" --format '{{json .Config.Entrypoint}}'
+
+    run_test T04 "Default CMD is [\"--version\"]" '^\["--version"\]$' \
+        docker image inspect "$IMAGE" --format '{{json .Config.Cmd}}'
+
+    run_test T05 "Running user is snorty (non-root)" 'snorty' \
+        docker image inspect "$IMAGE" --format '{{.Config.User}}'
+
+    run_test T06 "LD_LIBRARY_PATH set correctly" 'LD_LIBRARY_PATH=/usr/local/lib:/snort3/lib' \
+        docker image inspect "$IMAGE" --format '{{json .Config.Env}}'
+
+    run_test T07 "PATH includes /snort3/bin" '/snort3/bin' \
+        docker image inspect "$IMAGE" --format '{{json .Config.Env}}'
+
+    run_test T08 "Volume mounts declared" '/var/log/snort' \
+        docker image inspect "$IMAGE" --format '{{json .Config.Volumes}}'
+else
+    divider "Section A — Image Metadata (T01–T08)  [SKIPPED]"
+    for _id in T01 T02 T03 T04 T05 T06 T07 T08; do
+        skip_test "$_id" "Image metadata" "section A not selected"
+    done
+fi
+
+if $RUN_B; then
+    divider "Section B — Binary and Library Presence (T09–T24)"
+
+    run_test T09 "snort --version succeeds" 'Snort\+\+' \
+        docker run --rm ${PLATFORM:+--platform $PLATFORM} "$IMAGE" --version
+
+    run_test_sh T10 "snort binary in /snort3/bin" '/snort3/bin/snort' \
+        'ls /snort3/bin/snort'
+
+    if [[ "$PLATFORM" == *ppc64le* || "$PLATFORM" == *s390x* || "$PLATFORM" == *riscv64* ]]; then
+        skip_test T11 "libluajit-5.1 present" "LuaJIT has no upstream support for $PLATFORM"
+    else
+        run_test_sh T11 "libluajit-5.1 present (source-built, CVE-free)" 'libluajit' \
+            'ls /usr/local/lib/libluajit-5.1.so* 2>/dev/null'
+    fi
+
+    run_test_sh T12 "libdaq.so present" 'libdaq' \
+        'ls /usr/local/lib/libdaq.so* 2>/dev/null'
+
+    run_test_sh T13 "DAQ pcap module present" 'daq_pcap\.so' \
+        'ls /usr/local/lib/daq/daq_pcap.so'
+
+    run_test_sh T14 "DAQ dump module present" 'daq_dump\.so' \
+        'ls /usr/local/lib/daq/daq_dump.so'
+
+    run_test_sh T15 "Snort dynamic plugins directory exists" NON_EMPTY \
+        'ls /snort3/lib/snort/ 2>/dev/null'
+
+    run_test_sh T16 "Default snort.lua config present" 'snort\.lua' \
+        'ls /snort3/etc/snort/snort.lua'
+
+    run_test_sh T17 "libssl runtime library present" NON_EMPTY \
+        'find /usr/lib /lib -name "libssl.so*" 2>/dev/null | head -1'
+
+    run_test_sh T18 "libpcap runtime library present" NON_EMPTY \
+        'find /usr/lib /lib -name "libpcap.so*" 2>/dev/null | head -1'
+
+    run_test_sh T19 "libcrypto runtime library present" NON_EMPTY \
+        'find /usr/lib /lib -name "libcrypto.so*" 2>/dev/null | head -1'
+
+    run_test_sh T20 "snort binary is dynamically linked" '\.so' \
+        'ldd /snort3/bin/snort 2>&1'
+
+    if [[ "$PLATFORM" == *ppc64le* || "$PLATFORM" == *s390x* || "$PLATFORM" == *riscv64* ]]; then
+        skip_test T21 "snort links against libluajit" "LuaJIT not built on $PLATFORM"
+    else
+        run_test_sh T21 "snort links against libluajit" 'luajit' \
+            'ldd /snort3/bin/snort 2>/dev/null'
+    fi
+
+    run_test_sh T22 "snort links against libdaq" 'libdaq' \
+        'ldd /snort3/bin/snort 2>/dev/null'
+
+    run_test_sh T23 "snort links against libpcap" 'libpcap' \
+        'ldd /snort3/bin/snort 2>/dev/null'
+
+    printf "  ${BOLD}%-5s${RESET} %s ... " "T24" "No missing shared libraries"
+    _missing=$(docker run --rm --entrypoint sh "$IMAGE" -c \
+        'ldd /snort3/bin/snort 2>&1 | grep "not found" | wc -l' 2>/dev/null || echo 99)
+    if [[ "${_missing// /}" == "0" ]]; then
+        echo -e "${GREEN}PASS${RESET}"
+        (( PASS++ )) || true; PASSED_TESTS+=("T24: No missing shared libraries")
+    else
+        echo -e "${RED}FAIL${RESET}  ($_missing unresolved libraries)"
+        (( FAIL++ )) || true; FAILED_TESTS+=("T24: No missing shared libraries")
+    fi
+else
+    divider "Section B — Binary and Library Presence (T09–T24)  [SKIPPED]"
+    for _id in T09 T10 T11 T12 T13 T14 T15 T16 T17 T18 T19 T20 T21 T22 T23 T24; do
+        skip_test "$_id" "Binary/library check" "section B not selected"
+    done
+fi
+
+if $RUN_C; then
+    divider "Section C — Functional Tests (T25–T36)"
+
+    run_test T25 "Config validation -T passes" 'successfully validated' \
+        docker run --rm ${PLATFORM:+--platform $PLATFORM} "$IMAGE" -c /snort3/etc/snort/snort.lua -T
+
+    run_test T26 "Version string contains '3.'" '3\.' \
+        docker run --rm ${PLATFORM:+--platform $PLATFORM} "$IMAGE" --version
+
+    run_test_sh T27 "DAQ module list includes pcap" 'pcap' \
+        'snort --daq-list 2>&1'
+
+    run_test_sh T28 "Plugin list returns output" NON_EMPTY \
+        'snort --plugin-path /snort3/lib/snort --list-plugins 2>&1 | head -5'
+
+    _PCAP='
+printf "\xd4\xc3\xb2\xa1\x02\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x00\x00\x01\x00\x00\x00" > /tmp/t.pcap
+printf "\x00\x28\x99\x65\x00\x00\x00\x00\x2a\x00\x00\x00\x2a\x00\x00\x00" >> /tmp/t.pcap
+printf "\xff\xff\xff\xff\xff\xff\x00\x11\x22\x33\x44\x55\x08\x00" >> /tmp/t.pcap
+printf "\x45\x00\x00\x1c\x00\x01\x00\x00\x40\x01\xf8\x3a\xc0\xa8\x01\x64\x08\x08\x08\x08" >> /tmp/t.pcap
+printf "\x08\x00\xf7\xff\x00\x01\x00\x01" >> /tmp/t.pcap
+'
+    run_test_sh T29 "Pcap replay processes 1 packet" 'received:.*[1-9]|analyzed:.*[1-9]' \
+        "${_PCAP}snort -c /snort3/etc/snort/snort.lua -r /tmp/t.pcap -k none 2>&1"
+
+    run_test_sh T30 "Custom ICMP rule fires on replay" 'T30-ICMP' \
+        "${_PCAP}
+mkdir -p /tmp/rules
+echo 'alert icmp any any -> any any (msg:\"T30-ICMP\"; sid:9000001; rev:1;)' > /tmp/rules/test.rules
+snort -c /snort3/etc/snort/snort.lua --rule-path /tmp/rules -r /tmp/t.pcap -k none -A cmg 2>&1"
+
+    run_test_sh T31 "Custom TCP rule config validates cleanly" 'successfully validated' \
+        'mkdir -p /tmp/rules
+echo "alert tcp any any -> any 80 (msg:\"T31-HTTP\"; sid:9000002; rev:1;)" > /tmp/rules/test.rules
+snort -c /snort3/etc/snort/snort.lua --rule-path /tmp/rules -T 2>&1'
+
+    run_test_sh T32 "Alert written to fast log file" 'T32-FAST' \
+        "${_PCAP}
+mkdir -p /tmp/rules /tmp/logs
+echo 'alert icmp any any -> any any (msg:\"T32-FAST\"; sid:9000003; rev:1;)' > /tmp/rules/test.rules
+snort -c /snort3/etc/snort/snort.lua --rule-path /tmp/rules \
+      -r /tmp/t.pcap -k none -A fast -l /tmp/logs 2>&1
+cat /tmp/logs/alert_fast 2>/dev/null"
+
+    run_test_sh T33 "Container process runs as non-root (snorty)" 'snorty' \
+        'id'
+
+    printf "  ${BOLD}%-5s${RESET} %s ... " "T34" "/var/log/snort volume writable by snorty"
+    # Named volume so Docker inherits image ownership; avoids WSL2 host /tmp permission issues
+    docker volume create snort-t34 &>/dev/null
+    _out=$(timeout --kill-after=15 "${TEST_TIMEOUT:-60}" \
+        docker run --rm --stop-timeout 5 ${PLATFORM:+--platform $PLATFORM} \
+        -v snort-t34:/var/log/snort \
+        --entrypoint sh "$IMAGE" -c 'touch /var/log/snort/probe.txt && echo OK' 2>&1) || true
+    docker volume rm snort-t34 &>/dev/null
+    if echo "$_out" | grep -q "OK"; then
+        echo -e "${GREEN}PASS${RESET}"
+        (( PASS++ )) || true; PASSED_TESTS+=("T34: /var/log/snort volume writable by snorty")
+    else
+        echo -e "${RED}FAIL${RESET}  ($_out)"
+        (( FAIL++ )) || true; FAILED_TESTS+=("T34: /var/log/snort volume writable by snorty")
+    fi
+
+    echo "# T35 test rule" > /tmp/t35-rule.txt
+    run_test T35 "/snort3/etc/rules read-only volume readable" 'T35 test rule' \
+        docker run --rm --stop-timeout 5 ${PLATFORM:+--platform $PLATFORM} \
+            -v /tmp/t35-rule.txt:/snort3/etc/rules/local.rules:ro \
+            --entrypoint sh "$IMAGE" \
+            -c 'cat /snort3/etc/rules/local.rules'
+    rm -f /tmp/t35-rule.txt
+
+    printf "  ${BOLD}%-5s${RESET} %s ... " "T36" "Consecutive --version calls identical"
+    # grep Snort++ line specifically to avoid Docker platform-mismatch warnings on stderr
+    _v1=$(docker run --rm ${PLATFORM:+--platform $PLATFORM} "$IMAGE" --version 2>&1 | grep 'Snort++') || true
+    _v2=$(docker run --rm ${PLATFORM:+--platform $PLATFORM} "$IMAGE" --version 2>&1 | grep 'Snort++') || true
+    if [[ "$_v1" == "$_v2" && -n "$_v1" ]]; then
+        echo -e "${GREEN}PASS${RESET}"
+        (( PASS++ )) || true; PASSED_TESTS+=("T36: Consecutive --version calls identical")
+    else
+        echo -e "${RED}FAIL${RESET}  (outputs differ)"
+        (( FAIL++ )) || true; FAILED_TESTS+=("T36: Consecutive --version calls identical")
+    fi
+else
+    divider "Section C — Functional Tests (T25–T36)  [SKIPPED]"
+    for _id in T25 T26 T27 T28 T29 T30 T31 T32 T33 T34 T35 T36; do
+        skip_test "$_id" "Functional test" "section C not selected"
+    done
+fi
+
+if $RUN_D; then
+    divider "Section D — Live Interface (T37)"
+    run_test T37 "Config validation with live NIC ($OPT_IFACE)" 'successfully validated' \
+        docker run --rm --network host \
+            --cap-add NET_ADMIN --cap-add NET_RAW \
+            "$IMAGE" -c /snort3/etc/snort/snort.lua -i "$OPT_IFACE" -T
+else
+    divider "Section D — Live Interface (T37)  [SKIPPED]"
+    skip_test T37 "Live interface config validation" "section D not selected (use --live to enable)"
+fi
+
+if $RUN_E; then
+    divider "Section E — Trivy Security Scan (T38–T40)"
+
+    if ! command -v trivy &>/dev/null; then
+        log "Trivy not found — installing automatically..."
+
+        _os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+        _arch="$(uname -m)"
+        _trivy_ok=true
+
+        case "$_arch" in
+            x86_64)        _arch="64bit" ;;
+            aarch64|arm64) _arch="ARM64" ;;
+            armv7l)        _arch="ARM" ;;
+            *)
+                echo -e "  ${YELLOW}WARNING${RESET}: unsupported arch '$_arch' for Trivy auto-install."
+                echo -e "  Install manually: https://trivy.dev/latest/getting-started/installation/"
+                _trivy_ok=false ;;
+        esac
+
+        if $_trivy_ok; then
+            _ver="$(curl -fsSL \
+                https://api.github.com/repos/aquasecurity/trivy/releases/latest \
+                | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/')" || _ver=""
+
+            if [[ -z "$_ver" ]]; then
+                echo -e "  ${RED}ERROR${RESET}: Could not fetch latest Trivy version." >&2
+                _trivy_ok=false
+            else
+                _tmp="$(mktemp -d)"
+                trap 'rm -rf "$_tmp"' EXIT
+
+                if [[ "$_os" == "linux" ]]; then
+                    _pkg="trivy_${_ver}_Linux-${_arch}.tar.gz"
+                    curl -fsSL \
+                        "https://github.com/aquasecurity/trivy/releases/download/v${_ver}/${_pkg}" \
+                        -o "$_tmp/$_pkg"
+                    tar -xzf "$_tmp/$_pkg" -C "$_tmp"
+                elif [[ "$_os" == "darwin" ]]; then
+                    if command -v brew &>/dev/null; then
+                        brew install trivy
+                    else
+                        _pkg="trivy_${_ver}_macOS-${_arch}.tar.gz"
+                        curl -fsSL \
+                            "https://github.com/aquasecurity/trivy/releases/download/v${_ver}/${_pkg}" \
+                            -o "$_tmp/$_pkg"
+                        tar -xzf "$_tmp/$_pkg" -C "$_tmp"
+                    fi
+                fi
+
+                if [[ -f "$_tmp/trivy" ]]; then
+                    if command -v sudo &>/dev/null && sudo -n true 2>/dev/null; then
+                        sudo install -m 755 "$_tmp/trivy" /usr/local/bin/trivy
+                    else
+                        mkdir -p "$HOME/.local/bin"
+                        install -m 755 "$_tmp/trivy" "$HOME/.local/bin/trivy"
+                        export PATH="$HOME/.local/bin:$PATH"
+                    fi
+                fi
+
+                command -v trivy &>/dev/null \
+                    && log "Trivy $(trivy --version | head -1) installed." \
+                    || { echo -e "  ${RED}ERROR${RESET}: Trivy install failed." >&2; _trivy_ok=false; }
+            fi
+        fi
+
+        if ! $_trivy_ok; then
+            for _id in T38 T39 T40; do
+                skip_test "$_id" "Trivy scan" "trivy could not be installed"
+            done
+            _trivy_ok=false
+        fi
+    else
+        log "Trivy available: $(trivy --version | head -1)"
+        _trivy_ok=true
+    fi
+
+    if ${_trivy_ok:-true} && command -v trivy &>/dev/null; then
+        run_test T38 "Zero CRITICAL vulnerabilities" EXIT_0 \
+            trivy image --severity CRITICAL --scanners vuln --exit-code 1 --quiet "$IMAGE"
+
+        run_test T39 "Zero HIGH vulnerabilities" EXIT_0 \
+            trivy image --severity HIGH --scanners vuln --exit-code 1 --quiet "$IMAGE"
+
+        run_test T40 "No embedded secrets or credentials" EXIT_0 \
+            trivy image --scanners secret --exit-code 1 --quiet "$IMAGE"
+    fi
+else
+    divider "Section E — Trivy Security Scan (T38–T40)  [SKIPPED]"
+    for _id in T38 T39 T40; do
+        skip_test "$_id" "Trivy scan" "section E not selected (use --skip-trivy to exclude)"
+    done
+fi
+
+divider "Test Summary"
+TOTAL=$(( PASS + FAIL + SKIP ))
+
+_sections_run=""
+$RUN_A && _sections_run+=" A"
+$RUN_B && _sections_run+=" B"
+$RUN_C && _sections_run+=" C"
+$RUN_D && _sections_run+=" D"
+$RUN_E && _sections_run+=" E"
+
+echo ""
+echo -e "  Platform : ${BOLD}${PLATFORM:-native}${RESET}"
+echo -e "  Image    : ${BOLD}${IMAGE}${RESET}"
+echo -e "  Sections :${BOLD}${_sections_run}${RESET}"
+echo -e "  Total    : ${BOLD}${TOTAL}${RESET}  (passed: ${PASS}  failed: ${FAIL}  skipped: ${SKIP})"
+echo ""
+
+if [[ ${#PASSED_TESTS[@]} -gt 0 ]]; then
+    echo -e "  ${GREEN}${BOLD}Passed (${PASS}):${RESET}"
+    for _t in "${PASSED_TESTS[@]}"; do
+        echo -e "    ${GREEN}✔${RESET}  $_t"
+    done
+    echo ""
+fi
+
+if [[ ${#FAILED_TESTS[@]} -gt 0 ]]; then
+    echo -e "  ${RED}${BOLD}Failed (${FAIL}):${RESET}"
+    for _t in "${FAILED_TESTS[@]}"; do
+        echo -e "    ${RED}✘${RESET}  $_t"
+    done
+    echo ""
+fi
+
+if [[ ${#SKIPPED_TESTS[@]} -gt 0 ]]; then
+    echo -e "  ${GREY}${BOLD}Skipped (${SKIP}):${RESET}"
+    for _t in "${SKIPPED_TESTS[@]}"; do
+        echo -e "    ${GREY}–${RESET}  $_t"
+    done
+    echo ""
+fi
+
+if [[ $FAIL -eq 0 ]]; then
+    echo -e "  ${GREEN}${BOLD}All run tests passed.${RESET}"
+    echo ""
+    exit 0
+else
+    echo -e "  ${RED}${BOLD}$FAIL test(s) failed.${RESET}"
+    echo ""
+    exit 1
+fi

--- a/scripts/trivy-scan.sh
+++ b/scripts/trivy-scan.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# trivy-scan.sh: vulnerability + secret scan against the Snort 3 Docker image.
+# Installs Trivy if missing, builds the image if not present locally.
+#
+# Env vars (all optional):
+#   TRIVY_IMAGE      image to scan (default: snort3:alpine-test)
+#   DOCKERFILE_DIR   path containing the Dockerfile (default: repo root)
+#   REPORT_DIR       where to write reports (default: ./trivy-reports)
+#   TRIVY_SEVERITY   comma-separated severities (default: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL)
+#   TRIVY_FORMAT     report format: table|json|sarif|cyclonedx (default: table)
+#   TRIVY_EXIT_CODE  set to 1 to fail on CRITICAL/HIGH findings (default: 0)
+set -euo pipefail
+
+IMAGE="${TRIVY_IMAGE:-snort3:alpine-test}"
+DOCKERFILE_DIR="${DOCKERFILE_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+REPORT_DIR="${REPORT_DIR:-$(pwd)/trivy-reports}"
+SEVERITY="${TRIVY_SEVERITY:-UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL}"
+FORMAT="${TRIVY_FORMAT:-table}"
+EXIT_CODE="${TRIVY_EXIT_CODE:-0}"
+
+
+RED='\033[0;31m'; YELLOW='\033[1;33m'; GREEN='\033[0;32m'
+CYAN='\033[0;36m'; BOLD='\033[1m'; RESET='\033[0m'
+
+log()  { echo -e "${CYAN}[trivy-scan]${RESET} $*"; }
+ok()   { echo -e "${GREEN}[trivy-scan]${RESET} $*"; }
+warn() { echo -e "${YELLOW}[trivy-scan]${RESET} $*"; }
+die()  { echo -e "${RED}[trivy-scan] ERROR${RESET} $*" >&2; exit 1; }
+
+install_trivy() {
+    log "Trivy not found — installing..."
+
+    OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+    ARCH="$(uname -m)"
+
+    case "$ARCH" in
+        x86_64)  ARCH="64bit" ;;
+        aarch64|arm64) ARCH="ARM64" ;;
+        armv7l)  ARCH="ARM" ;;
+        *) die "Unsupported architecture: $ARCH" ;;
+    esac
+
+    TRIVY_VERSION="$(curl -fsSL \
+        https://api.github.com/repos/aquasecurity/trivy/releases/latest \
+        | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/')"
+
+    [[ -z "$TRIVY_VERSION" ]] && die "Could not determine latest Trivy version."
+    log "Installing Trivy v${TRIVY_VERSION} for ${OS}/${ARCH}..."
+
+    TMP="$(mktemp -d)"
+    trap 'rm -rf "$TMP"' EXIT
+
+    if [[ "$OS" == "linux" ]]; then
+        PKG="trivy_${TRIVY_VERSION}_Linux-${ARCH}.tar.gz"
+        curl -fsSL \
+            "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/${PKG}" \
+            -o "$TMP/$PKG"
+        tar -xzf "$TMP/$PKG" -C "$TMP"
+        if command -v sudo &>/dev/null && sudo -n true 2>/dev/null; then
+            sudo install -m 755 "$TMP/trivy" /usr/local/bin/trivy
+        else
+            mkdir -p "$HOME/.local/bin"
+            install -m 755 "$TMP/trivy" "$HOME/.local/bin/trivy"
+            export PATH="$HOME/.local/bin:$PATH"
+            warn "Trivy installed to ~/.local/bin — make sure that is in your PATH."
+        fi
+
+    elif [[ "$OS" == "darwin" ]]; then
+        if command -v brew &>/dev/null; then
+            brew install trivy
+        else
+            PKG="trivy_${TRIVY_VERSION}_macOS-${ARCH}.tar.gz"
+            curl -fsSL \
+                "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/${PKG}" \
+                -o "$TMP/$PKG"
+            tar -xzf "$TMP/$PKG" -C "$TMP"
+            mkdir -p "$HOME/.local/bin"
+            install -m 755 "$TMP/trivy" "$HOME/.local/bin/trivy"
+            export PATH="$HOME/.local/bin:$PATH"
+            warn "Trivy installed to ~/.local/bin — make sure that is in your PATH."
+        fi
+    else
+        die "Unsupported OS: $OS. Install Trivy manually: https://trivy.dev/latest/getting-started/installation/"
+    fi
+
+    ok "Trivy $(trivy --version | head -1) installed."
+}
+
+if ! command -v trivy &>/dev/null; then
+    install_trivy
+else
+    ok "Trivy already installed: $(trivy --version | head -1)"
+fi
+
+# build image if not present locally
+if ! docker image inspect "$IMAGE" &>/dev/null; then
+    warn "Image '${IMAGE}' not found locally — building..."
+    [[ -f "$DOCKERFILE_DIR/Dockerfile" ]] \
+        || die "Dockerfile not found at: $DOCKERFILE_DIR/Dockerfile"
+
+    docker build --platform linux/amd64 -t "$IMAGE" "$DOCKERFILE_DIR"
+    ok "Image '${IMAGE}' built successfully."
+else
+    ok "Image '${IMAGE}' found locally — skipping build."
+fi
+
+mkdir -p "$REPORT_DIR"
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+
+echo ""
+log "Trivy Vulnerability Scan — ${IMAGE}"
+echo ""
+
+log "Scanning OS packages and libraries..."
+trivy image \
+    --severity "$SEVERITY" \
+    --scanners vuln \
+    --format table \
+    "$IMAGE" \
+    | tee "$REPORT_DIR/scan_${TIMESTAMP}_table.txt"
+
+log "Writing JSON report..."
+trivy image \
+    --severity "$SEVERITY" \
+    --scanners vuln \
+    --format json \
+    --output "$REPORT_DIR/scan_${TIMESTAMP}.json" \
+    "$IMAGE"
+
+log "Writing SARIF report..."
+trivy image \
+    --severity "$SEVERITY" \
+    --scanners vuln \
+    --format sarif \
+    --output "$REPORT_DIR/scan_${TIMESTAMP}.sarif" \
+    "$IMAGE"
+
+log "Scanning for secrets..."
+trivy image \
+    --scanners secret \
+    --format table \
+    "$IMAGE" \
+    | tee "$REPORT_DIR/scan_${TIMESTAMP}_secrets.txt"
+
+echo ""
+log "Scan Summary"
+echo ""
+
+CRITICAL=$(grep -c '"Severity": "CRITICAL"' "$REPORT_DIR/scan_${TIMESTAMP}.json" 2>/dev/null || echo 0)
+HIGH=$(grep -c     '"Severity": "HIGH"'     "$REPORT_DIR/scan_${TIMESTAMP}.json" 2>/dev/null || echo 0)
+MEDIUM=$(grep -c   '"Severity": "MEDIUM"'   "$REPORT_DIR/scan_${TIMESTAMP}.json" 2>/dev/null || echo 0)
+LOW=$(grep -c      '"Severity": "LOW"'      "$REPORT_DIR/scan_${TIMESTAMP}.json" 2>/dev/null || echo 0)
+
+echo -e "  Image:     ${BOLD}${IMAGE}${RESET}"
+echo -e "  Timestamp: ${TIMESTAMP}"
+echo -e "  Severity filter: ${SEVERITY}"
+echo ""
+echo -e "  ${RED}CRITICAL${RESET}: ${CRITICAL}"
+echo -e "  ${RED}HIGH${RESET}:     ${HIGH}"
+echo -e "  ${YELLOW}MEDIUM${RESET}:   ${MEDIUM}"
+echo -e "  LOW:      ${LOW}"
+echo ""
+echo -e "  Reports saved to: ${BOLD}${REPORT_DIR}/${RESET}"
+echo -e "    ├── scan_${TIMESTAMP}_table.txt   (human-readable)"
+echo -e "    ├── scan_${TIMESTAMP}.json        (CI / SIEM)"
+echo -e "    ├── scan_${TIMESTAMP}.sarif       (GitHub / VS Code)"
+echo -e "    └── scan_${TIMESTAMP}_secrets.txt (secret scan)"
+echo ""
+
+if [[ "$EXIT_CODE" == "1" ]] && [[ "$CRITICAL" -gt 0 || "$HIGH" -gt 0 ]]; then
+    die "Scan found CRITICAL or HIGH vulnerabilities. Failing build."
+fi
+
+ok "Scan complete."


### PR DESCRIPTION
Closes #460.

## What this adds

**`Dockerfile`** four-stage build producing a minimal (~30–50 MB) Alpine runtime image with no compiler, headers, or build tools in the final layer.

- Stage 1: build tools and `-dev` headers (shared across all builder stages)
- Stage 2: LuaJIT (v2.1 branch, avoids CVE-2024-25176/25177/25178 in Alpine's packaged r0) and libdaq built from source
- Stage 3: Snort 3 built and installed; unit tests run via `make check` build fails if any test fails
- Stage 4: minimal runtime with only the shared libraries Snort needs

**`.github/workflows/docker.yml`** CI pipeline with one job per platform running in parallel. Each job follows this exact sequence and any failure blocks the next step:

1. `docker build`: unit tests run here inside the Dockerfile
2. Functional tests (`test-docker.sh` sections A B C, T01–T36)
3. Trivy vulnerability + secret scan (T38–T40) fails on CRITICAL/HIGH
4. Push to GHCR only if all tests pass

After all five platform jobs succeed, a manifest merge job combines the per-platform digests into a single multi-arch `latest` tag.

**`scripts/test-docker.sh`** 40 integration tests across five sections:

| Section | Tests   | Coverage                                   
|---------|---------|-----------------------------------------------------------------
| A       | T01–T08 | Image metadata, entrypoint, labels, volumes
| B       | T09–T24 | Binary presence, ldd, DAQ modules, missing .so
| C       | T25–T36 | Config validation, pcap replay, alert rules, volume permissions
| D       | T37     | Live NIC (opt-in via `--live`)
| E       | T38–T40 | Trivy CVE + secret scan

**`scripts/trivy-scan.sh`** standalone scan script; auto-installs Trivy if not present, outputs table/JSON/SARIF reports.

## Platform support

| Platform     |Pattern engine         | Notes
|--------------|-----------------------|----------------------------------------------
| linux/amd64  | Vectorscan + LuaJIT   | native build, full performance
| linux/arm64  | Vectorscan + LuaJIT   | native build, full performance
| linux/ppc64le| Vectorscan, no LuaJIT | no upstream LuaJIT PPC64 backend
| linux/arm/v7 | AC-BNFA + LuaJIT      | depends on #459 (SIGBUS fix for 32-bit ARM)
| linux/386    | AC-BNFA + LuaJIT      | Vectorscan not available for 32-bit x86

amd64 and arm64 use native GitHub runners; ppc64le, arm/v7, and 386 use QEMU.

## Testing

All 40 tests pass on linux/amd64, linux/arm64, and linux/arm/v7. Unit tests (162 tests via CppUTest) pass on all three platforms with zero failures.

The arm/v7 functional build depends on #459 being merged first, or `SNORT_REPO`/`SNORT_BRANCH` build args pointing to a branch that includes that fix.