### PR TITLE
Fix stdlog fd detection

### DIFF
--- a/src/log/text_log.cc
+++ b/src/log/text_log.cc
@@ -31,6 +31,7 @@
 
 #include "text_log.h"
 
+#include <fcntl.h>
 #include <sys/stat.h>
 #include <time.h>
 
@@ -79,11 +80,13 @@ static FILE* TextLog_Open(const char* name, bool is_critical=true)
     if ( !strcasecmp(name, "stdout") )
     {
 #ifdef USE_STDLOG
-        FILE* stdlog = fdopen(STDLOG_FILENO, "w");
-        return stdlog ? stdlog : stdout;
-#else
-        return stdout;
+        if ( fcntl(STDLOG_FILENO, F_GETFD) != -1 )
+        {
+            FILE* stdlog = fdopen(STDLOG_FILENO, "w");
+            return stdlog ? stdlog : stdout;
+        }
 #endif
+        return stdout;
     }
 
     return open_log_file(name, is_critical);


### PR DESCRIPTION
## Summary

This is a small starter contribution for issue #444.

When USE_STDLOG is enabled, TextLog_Open() currently calls dopen() on fd 3 and falls back to stdout only if dopen() fails. On musl, dopen() may not be a reliable way to determine whether fd 3 is actually present.

This checks fd 3 with cntl(F_GETFD) before calling dopen(), and falls back to stdout when STDLOG is not available.

## Testing

- git show --check --stat --oneline HEAD

I could not run the full Snort build locally because the WSL Ubuntu instance on this Windows machine is currently hanging before shell commands execute. The change is intentionally narrow and should be covered by CI/build validation.

Fixes #444