### PR TITLE
Avoid unaligned IPv4 address reads

### DIFF
--- a/src/codecs/ip/cd_ipv4.cc
+++ b/src/codecs/ip/cd_ipv4.cc
@@ -359,9 +359,11 @@ void Ipv4Codec::IP4AddrTests(
     const ip::IP4Hdr* iph, const CodecData& codec, DecodeData& snort)
 {
     uint8_t msb_src, msb_dst;
+    const uint32_t src_addr = iph->get_src();
+    const uint32_t dst_addr = iph->get_dst();
 
     // check all 32 bits ...
-    if ( iph->ip_src == iph->ip_dst )
+    if ( src_addr == dst_addr )
     {
         codec_event(codec, DECODE_BAD_TRAFFIC_SAME_SRCDST);
     }
@@ -376,11 +378,11 @@ void Ipv4Codec::IP4AddrTests(
     /* Loopback traffic  - don't use htonl for speed reasons -
      * s_addr is always in network order */
 #ifdef WORDS_BIGENDIAN
-    msb_src = (uint8_t)(iph->ip_src >> 24);
-    msb_dst = (uint8_t)(iph->ip_dst >> 24);
+    msb_src = (uint8_t)(src_addr >> 24);
+    msb_dst = (uint8_t)(dst_addr >> 24);
 #else
-    msb_src = (uint8_t)(iph->ip_src & 0xff);
-    msb_dst = (uint8_t)(iph->ip_dst & 0xff);
+    msb_src = (uint8_t)(src_addr & 0xff);
+    msb_dst = (uint8_t)(dst_addr & 0xff);
 #endif
     // check the msb ...
     if ( (msb_src == ip::IP4_LOOPBACK) || (msb_dst == ip::IP4_LOOPBACK) )
@@ -787,4 +789,3 @@ const BaseApi* cd_ipv4[] =
     &ipv4_api.base,
     nullptr
 };
-

--- a/src/protocols/ipv4.h
+++ b/src/protocols/ipv4.h
@@ -21,6 +21,7 @@
 #define PROTOCOLS_IPV4_H
 
 #include <arpa/inet.h>
+#include <cstring>
 
 #include "protocols/protocol_ids.h" // include ipv4 protocol numbers
 
@@ -100,10 +101,10 @@ struct IP4Hdr
 
     /* booleans */
     inline bool is_src_broadcast() const
-    { return ip_src == IP4_BROADCAST; }
+    { return get_src() == IP4_BROADCAST; }
 
     inline bool is_dst_broadcast() const
-    { return ip_dst == IP4_BROADCAST; }
+    { return get_dst() == IP4_BROADCAST; }
 
     inline bool has_options() const
     { return hlen() > 20; }
@@ -122,10 +123,18 @@ struct IP4Hdr
     { return ip_csum; }
 
     inline uint32_t get_src() const
-    { return ip_src; }
+    {
+        uint32_t value;
+        memcpy(&value, &ip_src, sizeof(value));
+        return value;
+    }
 
     inline uint32_t get_dst() const
-    { return ip_dst; }
+    {
+        uint32_t value;
+        memcpy(&value, &ip_dst, sizeof(value));
+        return value;
+    }
 
     /*  setters  */
     inline void set_hlen(uint8_t value)
@@ -158,4 +167,3 @@ inline bool isPrivateIP(uint32_t addr)
 } // namespace snort
 /* tcpdump shows us the way to cross platform compatibility */
 #endif
-

--- a/src/sfip/sf_ip.cc
+++ b/src/sfip/sf_ip.cc
@@ -28,6 +28,7 @@
 #include "sf_ip.h"
 
 #include <cmath> // For ceil
+#include <cstring>
 
 #include "utils/util.h"
 #include "utils/util_net.h"
@@ -314,7 +315,7 @@ SfIpRet SfIp::set(const void* src, int fam)
     {
         ip32[0] = ip32[1] = ip16[4] = 0;
         ip16[5] = 0xffff;
-        ip32[3] = *(const uint32_t*)src;
+        memcpy(&ip32[3], src, sizeof(ip32[3]));
     }
     else if (family == AF_INET6)
         memcpy(ip8, src, 16);
@@ -327,11 +328,21 @@ SfIpRet SfIp::set(const void* src, int fam)
 SfIpRet SfIp::set(const void* src)
 {
     assert(src);
-    if ( ((const uint32_t*)src)[0] == 0 &&
-         ((const uint32_t*)src)[1] == 0 &&
-         ((const uint16_t*)src)[4] == 0 &&
-         ((const uint16_t*)src)[5] == 0xffff )
-        return set(&((const uint32_t*)src)[3], AF_INET);
+
+    const uint8_t* bytes = static_cast<const uint8_t*>(src);
+    uint32_t word0;
+    uint32_t word1;
+    uint16_t word4;
+    uint16_t word5;
+
+    memcpy(&word0, bytes, sizeof(word0));
+    memcpy(&word1, bytes + sizeof(word0), sizeof(word1));
+    memcpy(&word4, bytes + 4 * sizeof(uint16_t), sizeof(word4));
+    memcpy(&word5, bytes + 5 * sizeof(uint16_t), sizeof(word5));
+
+    if ( word0 == 0 && word1 == 0 && word4 == 0 && word5 == 0xffff )
+        return set(bytes + 3 * sizeof(uint32_t), AF_INET);
+
     return set(src, AF_INET6);
 }
 


### PR DESCRIPTION
## Summary

This is a focused fix for part of issue #458.

On strict-alignment 32-bit ARM systems, IPv4 headers may start at an address that is not 4-byte aligned after an Ethernet header. Reading ip_src / ip_dst directly as uint32_t can therefore trap with SIGBUS.

This change uses byte-safe memcpy() reads for the affected IPv4 source/destination accessors and the SfIp::set() IPv4 path, then routes the IPv4 address tests through those accessors.

## Testing

- git diff --check
- git show --check --stat --oneline HEAD
- Static grep confirmed the named direct-read patterns from #458 are no longer present in the touched paths.

I could not run the full Snort build locally because the WSL Ubuntu instance on this Windows machine is currently hanging before shell commands execute. I kept the change narrow so CI and ARMv7 reporters can validate it directly.

Fixes the unaligned IPv4 read portion of #458