### PR TITLE
Document zlib 1.2.12 recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ the latest:
 * pcap from http://www.tcpdump.org for tcpdump style logging
 * PCRE2 from http://www.pcre.org for regular expression pattern matching
 * pkgconfig from https://www.freedesktop.org/wiki/Software/pkg-config/ to locate build dependencies
-* zlib from http://www.zlib.net for decompression
+* zlib >= 1.2.12 from http://www.zlib.net for decompression
 
 Additional packages provide optional features.  Check the manual for more.
 

--- a/doc/user/snort_user.text
+++ b/doc/user/snort_user.text
@@ -1088,7 +1088,7 @@ Required:
     matching
   * pkgconfig from https://www.freedesktop.org/wiki/Software/
     pkg-config/ to locate build dependencies
-  * zlib from http://www.zlib.net for decompression (>= 1.2.8
+  * zlib from http://www.zlib.net for decompression (>= 1.2.12
     recommended)
 
 Optional:

--- a/doc/user/tutorial.txt
+++ b/doc/user/tutorial.txt
@@ -31,7 +31,7 @@ Required:
 * pkgconfig from https://www.freedesktop.org/wiki/Software/pkg-config/ to locate
   build dependencies
 
-* zlib from http://www.zlib.net for decompression (>= 1.2.8 recommended)
+* zlib from http://www.zlib.net for decompression (>= 1.2.12 recommended)
 
 Optional:
 


### PR DESCRIPTION
## Summary

This is a small documentation update for issue #238.

The issue notes that zlib versions before 1.2.12 may be affected by CVE-2018-25032, and a maintainer commented that the docs should recommend zlib >= 1.2.12.

This updates the dependency wording in README.md, the user tutorial source, and the checked-in generated user text so they agree.

## Testing

- git diff --check
- git show --check --stat --oneline HEAD

No code changes.

Fixes #238