### PR TITLE
doc: recommend zlib 1.2.12 or newer

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ the latest:
 * pcap from http://www.tcpdump.org for tcpdump style logging
 * PCRE2 from http://www.pcre.org for regular expression pattern matching
 * pkgconfig from https://www.freedesktop.org/wiki/Software/pkg-config/ to locate build dependencies
-* zlib from http://www.zlib.net for decompression
+* zlib >= 1.2.12 from http://www.zlib.net for decompression
 
 Additional packages provide optional features.  Check the manual for more.
 

--- a/doc/user/snort_user.text
+++ b/doc/user/snort_user.text
@@ -1088,7 +1088,7 @@ Required:
     matching
   * pkgconfig from https://www.freedesktop.org/wiki/Software/
     pkg-config/ to locate build dependencies
-  * zlib from http://www.zlib.net for decompression (>= 1.2.8
+  * zlib from http://www.zlib.net for decompression (>= 1.2.12
     recommended)
 
 Optional:

--- a/doc/user/tutorial.txt
+++ b/doc/user/tutorial.txt
@@ -31,7 +31,7 @@ Required:
 * pkgconfig from https://www.freedesktop.org/wiki/Software/pkg-config/ to locate
   build dependencies
 
-* zlib from http://www.zlib.net for decompression (>= 1.2.8 recommended)
+* zlib from http://www.zlib.net for decompression (>= 1.2.12 recommended)
 
 Optional:
 


### PR DESCRIPTION
## Problem

The dependency documentation still recommends zlib `>= 1.2.8` in the user tutorial and does not list a minimum version in the README. In snort3/snort3#238, a maintainer noted that the docs should recommend zlib `>= 1.2.12`.

## Change

Update the zlib dependency wording in:

- `README.md`
- `doc/user/tutorial.txt`
- `doc/user/snort_user.text`

## Validation

- `git diff --check master..HEAD`
- `rg -n "zlib.*1\.2\.(8|12)|zlib from http://www\.zlib\.net for decompression" README.md doc/user/tutorial.txt doc/user/snort_user.text`
- Confirmed the changed zlib dependency references now use `>= 1.2.12`.

Related issue: snort3/snort3#238
