### PR TITLE
main: interrupt each analyzer's DAQ instance on quit so idle threads exit promptly

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -769,6 +769,17 @@ int main_quit(lua_State* L)
     send_response(ctrlcon, "== stopping\n");
     exit_requested = true;
     main_broadcast_command(new ACStop(), ctrlcon);
+
+    for (unsigned i = 0; i < max_pigs; ++i)
+    {
+        if (pigs[i].analyzer)
+        {
+            SFDAQInstance* daq = pigs[i].analyzer->get_daq_instance();
+            if (daq)
+                daq->interrupt();
+        }
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
On an idle interface, the analyzer thread sits inside the DAQ's `receive_messages()` waiting on `pcap_next_ex()` / equivalent, and the existing `main_quit()` only enqueues `ACStop` and sets `exit_requested`. The queued command isn't consumed until a packet arrives or the receive call returns on its own, so when Snort is run as a service and stopped via SIGTERM, it can hang well beyond the systemd stop timeout and require a SIGKILL, the symptom reported in #338. This change walks the active pigs in `main_quit()` and calls `interrupt()` on each analyzer's `SFDAQInstance` after broadcasting `ACStop`, allowing the underlying DAQ module to break the receive loop and process the queued stop command. For DAQ modules whose `interrupt()` simply sets a flag that's only read between blocking calls (the pcap module today is one of these), the receive-side change in [snort3/libdaq#XXX](https://github.com/snort3/libdaq/pull/XXX) is needed to actually wake a thread blocked inside `poll()`.

Fixes #338