### PR TITLE
appid: cap dynamic peg count ids

### DIFF
--- a/src/network_inspectors/appid/appid_peg_counts.cc
+++ b/src/network_inspectors/appid/appid_peg_counts.cc
@@ -158,6 +158,10 @@ void AppIdPegCounts::add_app_peg_info(std::string app_name, AppId app_id)
     std::replace(app_name.begin(), app_name.end(), ' ', '_');
 
     assert(appid_peg_ids);
+
+    if (appid_peg_ids->find(app_id) == appid_peg_ids->end() and appid_peg_ids->size() >= SF_APPID_MAX)
+        return;
+
     appid_peg_ids->emplace(app_id, std::make_pair(app_name, appid_peg_ids->size()));
 }
 

--- a/src/network_inspectors/appid/test/CMakeLists.txt
+++ b/src/network_inspectors/appid/test/CMakeLists.txt
@@ -36,6 +36,10 @@ add_cpputest( appid_debug_test
     SOURCES $<TARGET_OBJECTS:appid_cpputest_deps>
 )
 
+add_cpputest( appid_peg_counts_test
+    SOURCES $<TARGET_OBJECTS:appid_cpputest_deps>
+)
+
 add_cpputest( service_state_test
     SOURCES $<TARGET_OBJECTS:appid_cpputest_deps>
 )
@@ -81,5 +85,4 @@ endif ( ENABLE_UNIT_TESTS )
 add_cpputest( tp_appid_types_test
     SOURCES tp_appid_types_test.cc
 )
-
 

--- a/src/network_inspectors/appid/test/appid_peg_counts_test.cc
+++ b/src/network_inspectors/appid/test/appid_peg_counts_test.cc
@@ -1,0 +1,97 @@
+//--------------------------------------------------------------------------
+// Copyright (C) 2026-2026 Cisco and/or its affiliates. All rights reserved.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License Version 2 as published
+// by the Free Software Foundation.  You may not use, modify or distribute
+// this program under any other version of the GNU General Public License.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//--------------------------------------------------------------------------
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "../appid_peg_counts.h"
+#include "../appid_debug.h"
+#include "../app_info_table.h"
+
+#include <CppUTest/CommandLineTestRunner.h>
+#include <CppUTest/TestHarness.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+static std::vector<std::string> log_texts;
+
+namespace snort
+{
+void LogLabel(const char*, FILE*) {}
+void LogText(const char* s, FILE*) { log_texts.emplace_back(s); }
+
+char* snort_strdup(const char* str)
+{
+    char* dup = static_cast<char*>(malloc(strlen(str) + 1));
+    strcpy(dup, str);
+    return dup;
+}
+}
+
+THREAD_LOCAL AppIdDebug* appidDebug = nullptr;
+THREAD_LOCAL bool appid_trace_enabled = false;
+void appid_log(const snort::Packet*, unsigned char, char const*, ...) { }
+
+TEST_GROUP(appid_peg_counts_tests)
+{
+    void setup() override
+    {
+        log_texts.clear();
+        AppIdPegCounts::init_peg_info();
+    }
+
+    void teardown() override
+    {
+        AppIdPegCounts::cleanup_pegs();
+        AppIdPegCounts::cleanup_dynamic_sum();
+        AppIdPegCounts::cleanup_peg_info();
+        std::vector<std::string>().swap(log_texts);
+    }
+};
+
+TEST(appid_peg_counts_tests, over_limit_app_ids_are_reported_as_unknown)
+{
+    for (unsigned i = 0; i <= SF_APPID_MAX; ++i)
+        AppIdPegCounts::add_app_peg_info("app_" + std::to_string(i), static_cast<AppId>(i));
+
+    AppIdPegCounts::init_pegs();
+    AppIdPegCounts::inc_service_count(static_cast<AppId>(SF_APPID_MAX));
+    AppIdPegCounts::sum_stats();
+    AppIdPegCounts::print();
+
+    bool found_unknown = false;
+    bool found_over_limit_app = false;
+
+    for (const auto& line : log_texts)
+    {
+        found_unknown = found_unknown or line.find("unknown") != std::string::npos;
+        found_over_limit_app = found_over_limit_app or line.find("app_40000") != std::string::npos;
+    }
+
+    CHECK_TRUE(found_unknown);
+    CHECK_FALSE(found_over_limit_app);
+}
+
+int main(int argc, char** argv)
+{
+    return CommandLineTestRunner::RunAllTests(argc, argv);
+}


### PR DESCRIPTION
## Summary

This fixes a bounds issue in AppID dynamic peg count registration.

`appid_dynamic_sum` has slots for `SF_APPID_MAX` registered applications plus the `unknown` bucket. Before this change, `add_app_peg_info()` could keep assigning new dynamic peg indexes after that capacity was reached. Those indexes were later used to access `appid_dynamic_sum`, which could walk past the end of the array when AppIDs were sparse or exceeded the supported AppID range.

The change only registers a new AppID peg while there is room for a normal application slot. AppIDs beyond that capacity are left unregistered, so their counts continue through the existing unknown-AppID path instead of using an out-of-range dynamic index.

## Data Context

This affects AppID dynamic statistics emitted by `AppIdPegCounts`. The fix preserves the existing `unknown` bucket behavior for AppIDs that cannot be represented in the fixed-size dynamic stats array.

## Validation Methodology

Ran the new targeted regression test locally in WSL:

```bash
cmake -S . -B build-codex-make -G 'Unix Makefiles' -DENABLE_UNIT_TESTS=ON -DENABLE_SHELL=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo
cmake --build build-codex-make --target appid_peg_counts_test -j2
cd build-codex-make
ctest -R appid_peg_counts_test --output-on-failure
```

Result:

```text
100% tests passed, 0 tests failed out of 1
```

Also ran:

```bash
git diff --check HEAD^ HEAD
```

## Downstream Impact

The change is limited to AppID dynamic peg registration. Existing registered AppIDs keep their current indexes and output format. Over-capacity AppIDs are counted as unknown rather than risking an out-of-bounds stats access.

Fixes #66