### PR TITLE
alert_syslog: keep event metadata without IP

### DIFF
--- a/src/loggers/alert_syslog.cc
+++ b/src/loggers/alert_syslog.cc
@@ -201,29 +201,29 @@ static void AlertSyslog(
     char event_string[STD_BUF];
     event_string[0] = '\0';
 
+    uint32_t gid, sid, rev;
+    event.get_sig_ids(gid, sid, rev);
+    SnortSnprintfAppend(event_string, sizeof(event_string), "[%u:%u:%u] ", gid, sid, rev);
+
+    if (msg != nullptr)
+        SnortSnprintfAppend(event_string, sizeof(event_string), "%s ", msg);
+    else
+        SnortSnprintfAppend(event_string, sizeof(event_string), "ALERT ");
+
+    if ( auto cls = event.get_class_type() )
+    {
+        SnortSnprintfAppend(event_string, sizeof(event_string),
+            "[Classification: %s] ", cls);
+    }
+
+    if (event.get_priority() != 0)
+    {
+        SnortSnprintfAppend(event_string, sizeof(event_string),
+            "[Priority: %u] ", event.get_priority());
+    }
+
     if ((p != nullptr) && p->ptrs.ip_api.is_valid())
     {
-        uint32_t gid, sid, rev;
-        event.get_sig_ids(gid, sid, rev);
-        SnortSnprintfAppend(event_string, sizeof(event_string), "[%u:%u:%u] ", gid, sid, rev);
-
-        if (msg != nullptr)
-            SnortSnprintfAppend(event_string, sizeof(event_string), "%s ", msg);
-        else
-            SnortSnprintfAppend(event_string, sizeof(event_string), "ALERT ");
-
-        if ( auto cls = event.get_class_type() )
-        {
-            SnortSnprintfAppend(event_string, sizeof(event_string),
-                "[Classification: %s] ", cls);
-        }
-
-        if (event.get_priority() != 0)
-        {
-            SnortSnprintfAppend(event_string, sizeof(event_string),
-                "[Priority: %u] ", event.get_priority());
-        }
-
         if (p->context->conf->alert_interface())
         {
             SnortSnprintfAppend(event_string, sizeof(event_string),
@@ -283,12 +283,9 @@ static void AlertSyslog(
             }
         }
 
-        syslog(priority, "%s", event_string);
     }
-    else if (msg != nullptr)
-    {
-        syslog(priority, "%s", msg);
-    }
+
+    syslog(priority, "%s", event_string);
 }
 
 //-------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This updates `alert_syslog` so event metadata is still included when an alert does not have a packet with a valid IP header.

Before this change, `AlertSyslog()` only formatted the generator/signature/revision, message, classification, and priority inside the `p != nullptr && p->ptrs.ip_api.is_valid()` branch. If that branch was not available, syslog fell back to writing only the raw message. That made some inspector/internal alerts less useful in syslog than in other alert outputs.

The change builds the event metadata from `Event` unconditionally, then appends interface/protocol/address details only when the packet IP data is valid.

## Data Context

This affects syslog alert records. The schema-like text fields for event identity and severity are preserved for alerts without valid IP tuple data.

## Logic Adjustment

Moved event ID, message, classification, and priority formatting outside the packet/IP conditional. Packet-derived protocol and address fields remain guarded by the existing valid-IP check.

## Validation Methodology

Ran targeted build validation locally in WSL:

```bash
cmake --build build-codex-make --target loggers -j2
```

Result:

```text
Built target loggers
```

Also ran:

```bash
git diff --check HEAD^ HEAD
```

## Downstream Impact

No config or dependency changes. Syslog alerts without valid IP data now include the same event identity/severity context that packet-backed syslog alerts already included. Packet-backed syslog address formatting is unchanged.

Fixes #176