### PR TITLE
filters: reject non-internal total-count revert

### DIFF
--- a/src/filters/sfrf.cc
+++ b/src/filters/sfrf.cc
@@ -203,6 +203,9 @@ int SFRF_ConfigAdd(SnortConfig*, RateFilterConfig* rf_config, tSFRFConfigNode* c
     if ( cfgNode->count < 1 )
         return -1;
 
+    if ( !cfgNode->seconds && cfgNode->timeout && !EventIsInternal(cfgNode->gid) )
+        return -1;
+
     if ( cfgNode->timeout == 0 )
     {
         if ( rf_config->noRevertCount >= SFRF_NO_REVERT_LIMIT )

--- a/src/filters/sfrf_test.cc
+++ b/src/filters/sfrf_test.cc
@@ -23,6 +23,7 @@
 #endif
 
 #include "catch/snort_catch.h"
+#include "detection/rules.h"
 #include "main/snort_config.h"
 #include "parser/parse_ip.h"
 #include "sfip/sf_ip.h"
@@ -106,6 +107,10 @@ static RateData rfData[] =
     ,{ 100, 1000, TRK_SRC,  0,  0,  0, IP_ANY, -1, 0 }
     ,{ 100, 2000, TRK_DST,  0,  0,  0, IP_ANY, -1, 0 }
     ,{ 100, 3000, TRK_RUL,  0,  0,  0, IP_ANY, -1, 0 }
+
+    // total count with revert timeout applies only to internal session events
+    ,{ 100, 4110, TRK_SRC,  1,  0,  1, IP_ANY, -1, 0 }
+    ,{ GID_SESSION, SESSION_EVENT_SETUP, TRK_SRC,  1,  0,  1, IP_ANY,  0, 0 }
 
     // rate tests w/o apply ...
     ,{ 200, 1110, TRK_SRC,  1,  1,  0, IP_ANY,  0, 0 }


### PR DESCRIPTION
## Summary

This makes `rate_filter` reject `seconds = 0` with a revert timeout for non-internal generator IDs.

In issue #109, the reported configuration used `seconds = 0` and `timeout > 0` on a normal rule GID. The maintainer note says the total-count mode with revert timeout is only intended for internal session events (`GID_SESSION`, 135); other uses should fail configuration instead of silently creating a filter that will not revert as expected.

This adds that validation in `SFRF_ConfigAdd()` and extends the existing `sfrf` test data to cover both paths:

- non-internal GID with `seconds = 0` and `timeout > 0` is rejected
- internal session event with `seconds = 0` and `timeout > 0` remains accepted

## Data Context

This affects rate-filter configuration state. The change prevents a misleading configuration from entering the filter table when the filter cannot provide the expected revert behavior for non-internal events.

## Logic Adjustment

`SFRF_ConfigAdd()` now rejects total-count revert configurations unless `EventIsInternal(gid)` is true. Existing no-revert total-count configurations are unchanged.

## Validation Methodology

Ran targeted build validation locally in WSL:

```bash
cmake --build build-codex-make --target filter -j2
```

Result:

```text
Built target filter
```

Also ran:

```bash
git diff --check HEAD^ HEAD
```

## Downstream Impact

No dependency, schema, or output-format changes. Invalid non-internal total-count revert filters now fail during configuration instead of remaining active with surprising non-revert behavior. Internal session-event usage remains accepted.

Fixes #109