### PR TITLE
snort_ml fix context leak and add a test subdirectory

### DIFF
--- a/src/network_inspectors/snort_ml/CMakeLists.txt
+++ b/src/network_inspectors/snort_ml/CMakeLists.txt
@@ -6,3 +6,5 @@ add_library(snort_ml OBJECT
     snort_ml_module.cc
     snort_ml_module.h
 )
+
+add_subdirectory(test)

--- a/src/network_inspectors/snort_ml/snort_ml_engine.cc
+++ b/src/network_inspectors/snort_ml/snort_ml_engine.cc
@@ -51,8 +51,11 @@ static SnortMLContext* create_context(const SnortMLEngineConfig& conf)
     if (!ctx->classifiers.build(conf.http_param_models))
     {
         ErrorMessage("Could not build classifiers.\n");
-        return ctx;
+        delete ctx;
+        return nullptr;
     }
+
+    ctx->model_set_id = snort_ml_model_set_fingerprint(conf.http_param_models);
 
     if (conf.cache_memcap > 0)
     {
@@ -334,8 +337,10 @@ bool SnortMLEngine::scan(const char* buf, const size_t len, float& out) const
     float res = 0;
     bool is_new = true;
 
+    const uint64_t key = fnv1a(buf, len) ^ snort_ml_ctx->model_set_id;
+
     float& result = (snort_ml_ctx->cache) ?
-        snort_ml_ctx->cache->find_else_create(fnv1a(buf, len), &is_new) : res;
+        snort_ml_ctx->cache->find_else_create(key, &is_new) : res;
 
     if (is_new)
     {
@@ -413,9 +418,9 @@ const BaseApi* nin_snort_ml_engine[] =
 
 #include "catch/snort_catch.h"
 
-#include <memory.h>
+#include <cstring>
 
-TEST_CASE("SnortML tuner name", "[snort_ml_module]")
+TEST_CASE("SnortML tuner name", "[snort_ml_engine]")
 {
     SnortMLEngineConfig conf;
     conf.http_param_models = { "model" };
@@ -424,4 +429,43 @@ TEST_CASE("SnortML tuner name", "[snort_ml_module]")
     REQUIRE(strcmp(tuner.name(), "SnortMLReloadTuner") == 0);
 }
 
+TEST_CASE("SnortML create_context returns null on build failure", "[snort_ml_engine]")
+{
+    SnortMLEngineConfig conf;
+    conf.http_param_models = { "error" };
+
+    SnortMLContext* ctx = create_context(conf);
+
+    REQUIRE(ctx == nullptr);
+}
+
+TEST_CASE("SnortML create_context succeeds with valid model", "[snort_ml_engine]")
+{
+    SnortMLEngineConfig conf;
+    conf.http_param_models = { "needle" };
+
+    SnortMLContext* ctx = create_context(conf);
+
+    REQUIRE(ctx != nullptr);
+    REQUIRE(ctx->model_set_id != 0);
+    REQUIRE_FALSE(ctx->cache);
+
+    delete ctx;
+}
+
+TEST_CASE("SnortML create_context allocates cache when memcap > 0", "[snort_ml_engine]")
+{
+    SnortMLEngineConfig conf;
+    conf.http_param_models = { "needle" };
+    conf.cache_memcap = 4096;
+
+    SnortMLContext* ctx = create_context(conf);
+
+    REQUIRE(ctx != nullptr);
+    REQUIRE(ctx->cache);
+
+    delete ctx;
+}
+
 #endif
+

--- a/src/network_inspectors/snort_ml/snort_ml_engine.h
+++ b/src/network_inspectors/snort_ml/snort_ml_engine.h
@@ -25,12 +25,17 @@
 #include <libml.h>
 #endif
 
+#include <stdint.h>
+
 #include <memory>
+#include <string>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include "framework/inspector.h"
 #include "framework/module.h"
+#include "hash/fnv.h"
 #include "hash/lru_cache_local.h"
 #include "search_engines/search_tool.h"
 
@@ -83,7 +88,19 @@ struct SnortMLContext
 {
     libml::BinaryClassifierSet classifiers;
     std::unique_ptr<SnortMLCache> cache;
+    uint64_t model_set_id = 0;  // mixed into cache key to isolate verdicts per model set
 };
+
+inline uint64_t snort_ml_model_set_fingerprint(const std::vector<std::string>& models)
+{
+    uint64_t fp = FNV_BASIS;
+    for (const std::string& m : models)
+    {
+        uint64_t one = fnv1a(m.data(), m.size());
+        fp = (fp ^ one) * FNV_PRIME;
+    }
+    return fp;
+}
 
 struct SnortMLEngineConfig
 {

--- a/src/network_inspectors/snort_ml/snort_ml_inspector.cc
+++ b/src/network_inspectors/snort_ml/snort_ml_inspector.cc
@@ -23,7 +23,10 @@
 
 #include "snort_ml_inspector.h"
 
+#include <algorithm>
 #include <cassert>
+#include <cstdint>
+#include <limits>
 
 #include "detection/detection_engine.h"
 #include "log/messages.h"
@@ -40,6 +43,15 @@ using namespace std;
 
 THREAD_LOCAL SnortMLStats snort_ml_stats;
 THREAD_LOCAL ProfileStats snort_ml_prof;
+
+static inline size_t clamped_depth(int32_t cfg, int32_t actual)
+{
+    if (actual <= 0)
+        return 0;
+    if (cfg < 0)
+        return static_cast<size_t>(actual);
+    return std::min(static_cast<size_t>(cfg), static_cast<size_t>(actual));
+}
 
 //--------------------------------------------------------------------------
 // HTTP uri event handler
@@ -73,7 +85,9 @@ void HttpUriHandler::handle(DataEvent& de, Flow*)
 
     const SnortMLConfig& conf = inspector.get_config();
 
-    const size_t len = std::min((size_t)conf.uri_depth, (size_t)query_len);
+    const size_t len = clamped_depth(conf.uri_depth, query_len);
+    if (len == 0)
+        return;
 
     float output = 0;
     if (!engine.scan(query, len, output))
@@ -130,7 +144,9 @@ void HttpBodyHandler::handle(DataEvent& de, Flow*)
 
     const SnortMLConfig& conf = inspector.get_config();
 
-    const size_t len = std::min((size_t)conf.client_body_depth, (size_t)body_len);
+    const size_t len = clamped_depth(conf.client_body_depth, body_len);
+    if (len == 0)
+        return;
 
     float output = 0;
     if (!engine.scan(body, len, output))
@@ -183,7 +199,11 @@ void HttpFormHandler::handle(DataEvent& de, Flow*)
 
     const SnortMLConfig& conf = inspector.get_config();
 
-    const size_t len = std::min((size_t)conf.client_body_depth, data.length());
+    const int32_t form_len = static_cast<int32_t>(
+        std::min(data.length(), static_cast<size_t>(std::numeric_limits<int32_t>::max())));
+    const size_t len = clamped_depth(conf.client_body_depth, form_len);
+    if (len == 0)
+        return;
 
     float output = 0;
     if (!engine.scan(data.c_str(), len, output))
@@ -306,3 +326,4 @@ const BaseApi* nin_snort_ml[] =
     &snort_ml_api.base,
     nullptr
 };
+

--- a/src/network_inspectors/snort_ml/test/CMakeLists.txt
+++ b/src/network_inspectors/snort_ml/test/CMakeLists.txt
@@ -1,0 +1,6 @@
+
+add_catch_test(snort_ml_engine_test
+)
+
+add_catch_test(snort_ml_inspector_test
+)

--- a/src/network_inspectors/snort_ml/test/snort_ml_engine_test.cc
+++ b/src/network_inspectors/snort_ml/test/snort_ml_engine_test.cc
@@ -1,0 +1,111 @@
+//--------------------------------------------------------------------------
+// Copyright (C) 2022-2026 Cisco and/or its affiliates. All rights reserved.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License Version 2 as published
+// by the Free Software Foundation.  You may not use, modify or distribute
+// this program under any other version of the GNU General Public License.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//--------------------------------------------------------------------------
+// snort_ml_engine_test.cc author Samaresh Kumar Singh <ssam3003@gmail.com>
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "../snort_ml_engine.h"
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "catch/catch.hpp"
+
+//--------------------------------------------------------------------------
+// snort_ml_model_set_fingerprint
+//
+// The verdict cache key XORs the per-scan FNV with this fingerprint so
+// verdicts stay isolated if multiple classifier sets ever coexist. If the
+// fingerprint collided for distinct inputs, the cache could leak verdicts
+// across model sets.
+//--------------------------------------------------------------------------
+
+TEST_CASE("SnortML model_set_fingerprint deterministic", "[snort_ml_engine]")
+{
+    std::vector<std::string> a = { "alpha", "beta" };
+    std::vector<std::string> b = { "alpha", "beta" };
+
+    REQUIRE(snort_ml_model_set_fingerprint(a) == snort_ml_model_set_fingerprint(b));
+}
+
+TEST_CASE("SnortML model_set_fingerprint distinguishes content", "[snort_ml_engine]")
+{
+    REQUIRE(snort_ml_model_set_fingerprint({ "model_a" })
+        != snort_ml_model_set_fingerprint({ "model_b" }));
+}
+
+TEST_CASE("SnortML model_set_fingerprint distinguishes order", "[snort_ml_engine]")
+{
+    REQUIRE(snort_ml_model_set_fingerprint({ "a", "b" })
+        != snort_ml_model_set_fingerprint({ "b", "a" }));
+}
+
+TEST_CASE("SnortML model_set_fingerprint empty set", "[snort_ml_engine]")
+{
+    // An empty model set should still produce a stable value (the FNV
+    // basis) rather than 0 or unspecified.
+    REQUIRE(snort_ml_model_set_fingerprint({}) == FNV_BASIS);
+}
+
+TEST_CASE("SnortML model_set_fingerprint non-trivial size", "[snort_ml_engine]")
+{
+    std::string big(8192, 'x');
+    std::string also(8192, 'y');
+
+    REQUIRE(snort_ml_model_set_fingerprint({ big }) != 0);
+    REQUIRE(snort_ml_model_set_fingerprint({ big })
+        != snort_ml_model_set_fingerprint({ also }));
+}
+
+//--------------------------------------------------------------------------
+// Cache-key isolation
+//
+// snort_ml_engine.cc XORs the per-scan FNV with the context's
+// model_set_id, so two contexts with different model sets produce
+// different cache keys for the same buffer. Mirror the computation here
+// so the property stays pinned by an active test.
+//--------------------------------------------------------------------------
+
+static uint64_t compute_cache_key(const char* buf, size_t len, uint64_t model_set_id)
+{
+    return fnv1a(buf, len) ^ model_set_id;
+}
+
+TEST_CASE("SnortML cache key differs across model sets for same buffer", "[snort_ml_engine]")
+{
+    const char* buf = "GET /admin?user=alice";
+    const size_t len = std::strlen(buf);
+
+    const uint64_t id_a = snort_ml_model_set_fingerprint({ "model_v1" });
+    const uint64_t id_b = snort_ml_model_set_fingerprint({ "model_v2" });
+
+    REQUIRE(id_a != id_b);
+    REQUIRE(compute_cache_key(buf, len, id_a) != compute_cache_key(buf, len, id_b));
+}
+
+TEST_CASE("SnortML cache key is stable for same buffer and model set", "[snort_ml_engine]")
+{
+    const char* buf = "GET /";
+    const size_t len = std::strlen(buf);
+    const uint64_t id = snort_ml_model_set_fingerprint({ "model" });
+
+    REQUIRE(compute_cache_key(buf, len, id) == compute_cache_key(buf, len, id));
+}

--- a/src/network_inspectors/snort_ml/test/snort_ml_inspector_test.cc
+++ b/src/network_inspectors/snort_ml/test/snort_ml_inspector_test.cc
@@ -1,0 +1,87 @@
+//--------------------------------------------------------------------------
+// Copyright (C) 2026-2026 Cisco and/or its affiliates. All rights reserved.
+//
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License Version 2 as published
+// by the Free Software Foundation.  You may not use, modify or distribute
+// this program under any other version of the GNU General Public License.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//--------------------------------------------------------------------------
+// snort_ml_inspector_test.cc author Samaresh Kumar Singh <ssam3003@gmail.com>
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+
+#include "catch/catch.hpp"
+
+static inline size_t clamped_depth(int32_t cfg, int32_t actual)
+{
+    if (actual <= 0)
+        return 0;
+    if (cfg < 0)
+        return static_cast<size_t>(actual);
+    return std::min(static_cast<size_t>(cfg), static_cast<size_t>(actual));
+}
+
+//--------------------------------------------------------------------------
+// clamped_depth
+//
+// cfg = -1 means "unlimited" so the result is the actual length;
+// actual <= 0 means "nothing to scan" so the result is 0;
+// otherwise it is the smaller of cfg and actual. Casting -1 to size_t
+// previously produced SIZE_MAX which only worked by accident inside
+// std::min; these tests pin the explicit semantics in place.
+//--------------------------------------------------------------------------
+
+TEST_CASE("SnortML clamped_depth unlimited cfg uses actual", "[snort_ml]")
+{
+    REQUIRE(clamped_depth(-1, 100) == 100u);
+    REQUIRE(clamped_depth(-1, 1) == 1u);
+}
+
+TEST_CASE("SnortML clamped_depth zero actual returns zero", "[snort_ml]")
+{
+    REQUIRE(clamped_depth(-1, 0) == 0u);
+    REQUIRE(clamped_depth(0, 0) == 0u);
+    REQUIRE(clamped_depth(100, 0) == 0u);
+}
+
+TEST_CASE("SnortML clamped_depth negative actual returns zero", "[snort_ml]")
+{
+    REQUIRE(clamped_depth(-1, -5) == 0u);
+    REQUIRE(clamped_depth(100, -1) == 0u);
+}
+
+TEST_CASE("SnortML clamped_depth cfg below actual", "[snort_ml]")
+{
+    REQUIRE(clamped_depth(50, 200) == 50u);
+}
+
+TEST_CASE("SnortML clamped_depth cfg above actual", "[snort_ml]")
+{
+    REQUIRE(clamped_depth(500, 200) == 200u);
+}
+
+TEST_CASE("SnortML clamped_depth cfg equals actual", "[snort_ml]")
+{
+    REQUIRE(clamped_depth(200, 200) == 200u);
+}
+
+TEST_CASE("SnortML clamped_depth max int32 actual", "[snort_ml]")
+{
+    REQUIRE(clamped_depth(-1, std::numeric_limits<int32_t>::max())
+        == static_cast<size_t>(std::numeric_limits<int32_t>::max()));
+}


### PR DESCRIPTION

The most important change is in create_context where a classifier build failure used to hand back a half built context that scan kept treating as live. Now the partial context is deleted and the function returns null so scan early exits and libml_calls stops incrementing on nothing. The three HTTP handler length caps move to a small clamped_depth helper so the int32 t to size t SIZE_MAX trick is no longer load bearing and the intent is explicit. The verdict cache key now mixes in a fingerprint of the model bytes, which is a constant per thread today but keeps verdicts isolated if multiple classifier sets ever coexist. Fixes #472.